### PR TITLE
[015-USER-CI/CD] Dockerfile의 build path 수정

### DIFF
--- a/user-api/Dockerfile
+++ b/user-api/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-COPY ./build/libs/*.jar app.jar
+COPY ./*.jar app.jar
 
 EXPOSE 8080
 


### PR DESCRIPTION
## 변경사항
- Jenkinsfile 이미지 빌드 경로 수정

발생 이슈
- [#6](https://github.com/hellmir/yeongyulgori/pull/6) 배포 서버에서 지속적으로 ${PROJECT_NAME}을 통해 schema에 접근하는 문제

해결 과정
- [#13](https://github.com/hellmir/yeongyulgori/pull/13) multi module 구조에 맞춰 Jenkinsfile의 build, deploy path를 pipeline name/script path 경로로 조정함으로써 이전의 파일을 재사용하는 문제 해결

- 변경한 Jenkinsfile에 맞춰 Dockerfile의 이미지 빌드 경로 수정