### PR TITLE
[025-USER-SECURITY] Spring Security 적용

### DIFF
--- a/user-api/src/main/java/personal/yeongyulgori/user/aspect/LoggingAspect.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/aspect/LoggingAspect.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 import personal.yeongyulgori.user.model.form.SignInForm;
 import personal.yeongyulgori.user.model.form.SignUpForm;
+import personal.yeongyulgori.user.utility.MemoryUtil;
 
 @Component
 @Aspect
@@ -24,16 +25,19 @@ public class LoggingAspect {
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), signUpForm.getEmail(), signUpForm.getUsername());
 
+        long beforeMemory = MemoryUtil.usedMemory();
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
 
         Object process = joinPoint.proceed();
 
         stopWatch.stop();
-        log.info("'{}.{}' task was executed successfully by 'email: {}', 'username: {}', estimated time: {}ms",
+        long memoryUsage = MemoryUtil.usedMemory() - beforeMemory;
+
+        log.info("'{}.{}' task was executed successfully by 'email: {}', 'username: {}', estimated time: {} ms, used memory: {} bytes",
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), signUpForm.getEmail(), signUpForm.getUsername(),
-                stopWatch.getTotalTimeMillis());
+                stopWatch.getTotalTimeMillis(), memoryUsage);
 
         return process;
 
@@ -46,17 +50,19 @@ public class LoggingAspect {
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), signInForm.getEmailOrUsername());
 
+        long beforeMemory = MemoryUtil.usedMemory();
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
 
         Object process = joinPoint.proceed();
 
         stopWatch.stop();
+        long memoryUsage = MemoryUtil.usedMemory() - beforeMemory;
 
-        log.info("'{}.{}' task was executed successfully by 'email or username: {}', estimated time: {}ms",
+        log.info("'{}.{}' task was executed successfully by 'email or username: {}', estimated time: {} ms, used memory: {} bytes",
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), signInForm.getEmailOrUsername(),
-                stopWatch.getTotalTimeMillis());
+                stopWatch.getTotalTimeMillis(), memoryUsage);
 
         return process;
 
@@ -71,17 +77,19 @@ public class LoggingAspect {
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), parameterName, stringValue);
 
+        long beforeMemory = MemoryUtil.usedMemory();
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
 
         Object process = joinPoint.proceed();
 
         stopWatch.stop();
+        long memoryUsage = MemoryUtil.usedMemory() - beforeMemory;
 
-        log.info("'{}.{}' task was executed successfully by '{}: {}', estimated time: {}ms",
+        log.info("'{}.{}' task was executed successfully by '{}: {}', estimated time: {} ms, used memory: {} bytes",
                 joinPoint.getSignature().getDeclaringType().getSimpleName(),
                 joinPoint.getSignature().getName(), parameterName, stringValue,
-                stopWatch.getTotalTimeMillis());
+                stopWatch.getTotalTimeMillis(), memoryUsage);
 
         return process;
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/configuration/PasswordConfig.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/configuration/PasswordConfig.java
@@ -1,0 +1,16 @@
+package personal.yeongyulgori.user.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/configuration/WebSecurityConfig.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/configuration/WebSecurityConfig.java
@@ -1,0 +1,50 @@
+package personal.yeongyulgori.user.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import personal.yeongyulgori.user.security.CustomAuthenticationEntryPoint;
+import personal.yeongyulgori.user.security.JwtAuthenticationFilter;
+import personal.yeongyulgori.user.security.JwtTokenProvider;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+                .exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint) // 인증되지 않았을 시 custom entry point 사용
+                .and()
+                .httpBasic().disable() // JWT 사용
+                .csrf().disable() // REST API는 Stateless한 특성을 가지므로, Session 미사용 -> CSRF 보호 비활성화
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeHttpRequests()
+                .antMatchers("/", "/swagger-ui/**", "/v2/api-docs", "/swagger-resources/**",
+                        "/**/signup", "/**/login", "/users/v1", "/users/v1/auto-complete")
+                .permitAll()
+                .antMatchers(HttpMethod.GET, "/users/v1/{username}").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter
+                                (jwtTokenProvider, customAuthenticationEntryPoint),
+                        UsernamePasswordAuthenticationFilter.class)
+                .logout().permitAll();
+
+        return http.build();
+
+    }
+
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/configuration/WebSecurityConfig.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/configuration/WebSecurityConfig.java
@@ -33,7 +33,8 @@ public class WebSecurityConfig {
                 .and()
                 .authorizeHttpRequests()
                 .antMatchers("/", "/swagger-ui/**", "/v2/api-docs", "/swagger-resources/**",
-                        "/**/signup", "/**/login", "/users/v1", "/users/v1/auto-complete")
+                        "/**/signup", "/**/login", "/users/v1", "/users/v1/auto-complete",
+                        "/users/v1/password-reset/**")
                 .permitAll()
                 .antMatchers(HttpMethod.GET, "/users/v1/{username}").permitAll()
                 .anyRequest().authenticated()

--- a/user-api/src/main/java/personal/yeongyulgori/user/controller/AuthenticationController.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/controller/AuthenticationController.java
@@ -103,16 +103,15 @@ public class AuthenticationController {
 
     }
 
-
     @ApiOperation(value = "비밀번호 재설정 요청", notes = "비밀번호를 잊어 버린 경우 인증을 통해 재설정을 요청할 수 있습니다.")
     @PostMapping("password-reset/request")
-    public ResponseEntity<Void> requestPasswordReset
+    public ResponseEntity<String> requestPasswordReset
             (@ApiParam(value = "이메일 주소", example = "abcd@abc.com") @RequestParam String email) {
 
         String token = jwtTokenProvider.generateToken(email);
-        authenticationService.requestPasswordReset(email, token);
+        String passwordResetUrl = authenticationService.requestPasswordReset(email, token);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.status(HttpStatus.OK).body(passwordResetUrl);
 
     }
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/controller/UserController.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/controller/UserController.java
@@ -53,7 +53,7 @@ public class UserController {
             @ApiImplicitParam(name = "sort.unsorted", value = "정렬 미사용 여부", dataTypeClass = Boolean.class,
                     paramType = "query", defaultValue = "false", example = "false"),
             @ApiImplicitParam(name = "sort", value = "정렬 방식", dataTypeClass = String.class,
-                    paramType = "query", defaultValue = "name,asc", example = "name,asc")
+                    paramType = "query", defaultValue = "fullName,asc", example = "fullName,asc")
     })
     @GetMapping()
     public ResponseEntity<Page<UserResponseDto>> searchUsers

--- a/user-api/src/main/java/personal/yeongyulgori/user/exception/GlobalExceptionHandler.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package personal.yeongyulgori.user.exception;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -90,6 +91,21 @@ public class GlobalExceptionHandler {
 
         ErrorResponse errorResponse = ErrorResponse.builder()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
+                .message(e.getMessage())
+                .build();
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+
+    }
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    private ResponseEntity<ErrorResponse> handleExpiredJwtException
+            (ExpiredJwtException e) {
+
+        log.info("Exception occurred: {}", e.getMessage(), e);
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
                 .message(e.getMessage())
                 .build();
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/exception/significant/sub/TokenExpiredException.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/exception/significant/sub/TokenExpiredException.java
@@ -1,0 +1,17 @@
+package personal.yeongyulgori.user.exception.significant.sub;
+
+import org.springframework.http.HttpStatus;
+import personal.yeongyulgori.user.exception.significant.AbstractSignificantException;
+
+public class TokenExpiredException extends AbstractSignificantException {
+
+    public TokenExpiredException() {
+        super("토큰이 만료되었습니다. 비밀번호를 재설정하려면 새로운 토큰을 발급 받아야 합니다.");
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.UNAUTHORIZED.value();
+    }
+
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/constant/Role.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/constant/Role.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 public enum Role {
 
     ROLE_ADMIN("관리자"),
-    GENERAL_USER("일반 사용자"),
-    BUSINESS_USER("기업 고객");
+    ROLE_GENERAL_USER("일반 사용자"),
+    ROLE_BUSINESS_USER("기업 고객");
 
     private final String description;
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/dto/CrucialInformationUpdateDto.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/dto/CrucialInformationUpdateDto.java
@@ -29,4 +29,8 @@ public class CrucialInformationUpdateDto {
     @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 잘못되었습니다. 예: 01012345678")
     private String phoneNumber;
 
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+
 }

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/dto/CrucialInformationUpdateDto.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/dto/CrucialInformationUpdateDto.java
@@ -15,14 +15,17 @@ public class CrucialInformationUpdateDto {
     @ApiModelProperty(value = "id", example = "1")
     private Long id;
 
-    @ApiModelProperty(value = "이메일 주소", example = "abcd@abc.com")
+    @ApiModelProperty(value = "현재 비밀번호", example = "1234")
+    private String password;
+
+    @ApiModelProperty(value = "변경할 비밀번호", example = "12345")
+    private String newPassword;
+
+    @ApiModelProperty(value = "변경할 이메일 주소", example = "abcd@abc.com")
     @Email(message = "이메일 주소 형식이 잘못되었습니다. 예: abcd@abc.com")
     private String email;
 
-    @ApiModelProperty(value = "비밀번호", example = "1234")
-    private String password;
-
-    @ApiModelProperty(value = "휴대폰 번호", example = "01012345678")
+    @ApiModelProperty(value = "변경할 휴대폰 번호", example = "01012345678")
     @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 잘못되었습니다. 예: 01012345678")
     private String phoneNumber;
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/dto/PasswordRequestDto.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/dto/PasswordRequestDto.java
@@ -1,0 +1,18 @@
+package personal.yeongyulgori.user.model.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordRequestDto {
+
+    @ApiModelProperty(value = "비밀번호", example = "1234")
+    private String password;
+
+    public PasswordRequestDto(String password) {
+        this.password = password;
+    }
+
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/dto/SignInResponseDto.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/dto/SignInResponseDto.java
@@ -1,22 +1,22 @@
 package personal.yeongyulgori.user.model.dto;
 
 import lombok.Getter;
-import org.springframework.security.core.GrantedAuthority;
+import personal.yeongyulgori.user.model.constant.Role;
 
-import java.util.Collection;
+import java.util.List;
 
 @Getter
 public class SignInResponseDto {
 
     private String username;
-    private Collection<? extends GrantedAuthority> roles;
+    private List<Role> roles;
 
-    private SignInResponseDto(String username, Collection<? extends GrantedAuthority> roles) {
+    private SignInResponseDto(String username, List<Role> roles) {
         this.username = username;
         this.roles = roles;
     }
 
-    public static SignInResponseDto of(String username, Collection<? extends GrantedAuthority> roles) {
+    public static SignInResponseDto of(String username, List<Role> roles) {
         return new SignInResponseDto(username, roles);
     }
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/dto/SignInResponseDto.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/dto/SignInResponseDto.java
@@ -1,0 +1,23 @@
+package personal.yeongyulgori.user.model.dto;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+@Getter
+public class SignInResponseDto {
+
+    private String username;
+    private Collection<? extends GrantedAuthority> roles;
+
+    private SignInResponseDto(String username, Collection<? extends GrantedAuthority> roles) {
+        this.username = username;
+        this.roles = roles;
+    }
+
+    public static SignInResponseDto of(String username, Collection<? extends GrantedAuthority> roles) {
+        return new SignInResponseDto(username, roles);
+    }
+
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/dto/UserResponseDto.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/dto/UserResponseDto.java
@@ -1,15 +1,20 @@
 package personal.yeongyulgori.user.model.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import personal.yeongyulgori.user.constant.Role;
-import personal.yeongyulgori.user.model.Address;
+import personal.yeongyulgori.user.model.constant.Role;
 import personal.yeongyulgori.user.model.entity.User;
+import personal.yeongyulgori.user.model.entity.embedment.Address;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Base64;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -19,26 +24,31 @@ public class UserResponseDto {
     private Long id;
     private String email;
     private String username;
-    private String name;
+    private String fullName;
     private LocalDate birthDate;
     private String phoneNumber;
     private Address address;
-    private Role role;
+    private List<Role> roles;
     private String profileImage;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime modifiedAt;
 
     public static UserResponseDto of(
-            String email, String username, String name,
-            Role role, LocalDateTime createdAt, LocalDateTime modifiedAt
+            String email, String username, String fullName,
+            List<Role> roles, LocalDateTime createdAt, LocalDateTime modifiedAt
     ) {
 
         return UserResponseDto.builder()
                 .email(email)
                 .username(username)
-                .name(name)
-                .role(role)
+                .fullName(fullName)
+                .roles(roles)
                 .createdAt(createdAt)
                 .modifiedAt(modifiedAt)
                 .build();
@@ -51,11 +61,11 @@ public class UserResponseDto {
                 .id(user.getId())
                 .email(user.getEmail())
                 .username(user.getUsername())
-                .name(user.getName())
+                .fullName(user.getFullName())
                 .birthDate(user.getBirthDate())
                 .phoneNumber(user.getPhoneNumber())
                 .address(user.getAddress())
-                .role(user.getRole())
+                .roles(user.getRoles())
                 .profileImage(user.getProfileImage() != null ?
                         Base64.getEncoder().encodeToString(user.getProfileImage()) : null)
                 .createdAt(user.getCreatedAt())

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/entity/PasswordResetToken.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/entity/PasswordResetToken.java
@@ -1,0 +1,42 @@
+package personal.yeongyulgori.user.model.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+import static personal.yeongyulgori.user.security.JwtTokenProvider.PASSWORD_RESET_TOKEN_EXPIRATION_TIME;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "password_reset_token")
+public class PasswordResetToken {
+
+    @Id
+    private String token;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime expirationDate;
+
+    private PasswordResetToken(String token, User user, LocalDateTime expirationDate) {
+        this.token = token;
+        this.user = user;
+        this.expirationDate = expirationDate;
+    }
+
+    public static PasswordResetToken of(String token, User user) {
+        LocalDateTime expirationDate = LocalDateTime.now().plusMinutes(PASSWORD_RESET_TOKEN_EXPIRATION_TIME / 1_000);
+        return new PasswordResetToken(token, user, expirationDate);
+    }
+
+    public void setExpirationDate(LocalDateTime expirationDate) {
+        this.expirationDate = expirationDate;
+    }
+
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/entity/User.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/entity/User.java
@@ -138,7 +138,7 @@ public class User extends BaseEntity implements UserDetails {
                 .id(id)
                 .email(Optional.ofNullable(crucialInformationUpdateDto.getEmail()).orElse(email))
                 .username(username)
-                .password(Optional.ofNullable(crucialInformationUpdateDto.getPassword()).orElse(password))
+                .password(Optional.ofNullable(crucialInformationUpdateDto.getNewPassword()).orElse(password))
                 .fullName(fullName)
                 .birthDate(birthDate)
                 .phoneNumber(Optional.ofNullable(crucialInformationUpdateDto.getPhoneNumber()).orElse(phoneNumber))

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/entity/User.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/entity/User.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import personal.yeongyulgori.user.base.BaseEntity;
 import personal.yeongyulgori.user.model.constant.Role;
 import personal.yeongyulgori.user.model.dto.CrucialInformationUpdateDto;
+import personal.yeongyulgori.user.model.dto.PasswordRequestDto;
 import personal.yeongyulgori.user.model.entity.embedment.Address;
 import personal.yeongyulgori.user.model.form.InformationUpdateForm;
 import personal.yeongyulgori.user.model.form.SignUpForm;
@@ -141,6 +142,24 @@ public class User extends BaseEntity implements UserDetails {
                 .fullName(fullName)
                 .birthDate(birthDate)
                 .phoneNumber(Optional.ofNullable(crucialInformationUpdateDto.getPhoneNumber()).orElse(phoneNumber))
+                .address(address)
+                .roles(roles)
+                .profileImage(profileImage)
+                .createdAt(getCreatedAt())
+                .build();
+
+    }
+
+    public User withPassword(PasswordRequestDto passwordRequestDto) {
+
+        return User.builder()
+                .id(id)
+                .email(email)
+                .username(username)
+                .password(passwordRequestDto.getPassword())
+                .fullName(fullName)
+                .birthDate(birthDate)
+                .phoneNumber(phoneNumber)
                 .address(address)
                 .roles(roles)
                 .profileImage(profileImage)

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/form/InformationUpdateForm.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/form/InformationUpdateForm.java
@@ -2,8 +2,10 @@ package personal.yeongyulgori.user.model.form;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
-import personal.yeongyulgori.user.constant.Role;
-import personal.yeongyulgori.user.model.Address;
+import personal.yeongyulgori.user.model.constant.Role;
+import personal.yeongyulgori.user.model.entity.embedment.Address;
+
+import java.util.List;
 
 
 @Getter
@@ -16,12 +18,12 @@ public class InformationUpdateForm {
     private Long id;
 
     @ApiModelProperty(value = "성명", example = "고길동")
-    private String name;
+    private String fullName;
 
     private Address address;
 
-    @ApiModelProperty(value = "분류", example = "BUSINESS_USER")
-    private Role role;
+    @ApiModelProperty(value = "권한", example = "ROLE_BUSINESS_USER")
+    private List<Role> roles;
 
     @ApiModelProperty(value = "Base64로 인코딩된 프로필 이미지 데이터 URI", example = "NewEncodedDataURI")
     private String profileImage;

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/form/SignInForm.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/form/SignInForm.java
@@ -3,7 +3,6 @@ package personal.yeongyulgori.user.model.form;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
 @Getter
@@ -12,12 +11,8 @@ import javax.validation.constraints.NotBlank;
 @Builder
 public class SignInForm {
 
-    @ApiModelProperty(value = "email", example = "abcd@abc.com")
-    @Email(message = "이메일 주소 형식이 잘못되었습니다.")
-    private String email;
-
-    @ApiModelProperty(value = "username", example = "gildong1234")
-    private String username;
+    @ApiModelProperty(value = "email or username", example = "abcd@abc.com")
+    private String emailOrUsername;
 
     @ApiModelProperty(value = "password", example = "1234")
     @NotBlank(message = "비밀번호는 필수값입니다.")

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/form/SignUpForm.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/form/SignUpForm.java
@@ -2,8 +2,8 @@ package personal.yeongyulgori.user.model.form;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
-import personal.yeongyulgori.user.constant.Role;
-import personal.yeongyulgori.user.model.Address;
+import personal.yeongyulgori.user.model.constant.Role;
+import personal.yeongyulgori.user.model.entity.embedment.Address;
 import personal.yeongyulgori.user.validation.group.OnSignUp;
 
 import javax.validation.Valid;
@@ -12,6 +12,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,6 +27,8 @@ public class SignUpForm {
 
     @ApiModelProperty(value = "사용자 이름", example = "gildong1234")
     @NotBlank(groups = OnSignUp.class, message = "사용자 이름은 필수값입니다.")
+    @Pattern(groups = OnSignUp.class, regexp = "^[a-z0-9]{4,16}$",
+            message = "사용자 이름은 4~16자 이하의 영소문자와 숫자만으로 구성되어야 합니다. 예: gildong1234")
     private String username;
 
     @ApiModelProperty(value = "비밀번호", example = "1234")
@@ -34,7 +37,7 @@ public class SignUpForm {
 
     @ApiModelProperty(value = "성명", example = "홍길동")
     @NotBlank(groups = OnSignUp.class, message = "성명은 필수값입니다.")
-    private String name;
+    private String fullName;
 
     @ApiModelProperty(value = "생일", example = "2000-01-01")
     @NotNull(groups = OnSignUp.class, message = "생일은 필수값입니다.")
@@ -47,9 +50,9 @@ public class SignUpForm {
     @Valid
     private Address address;
 
-    @ApiModelProperty(value = "분류", example = "GENERAL_USER")
+    @ApiModelProperty(value = "분류", example = "[ROLE_GENERAL_USER, ROLE_BUSINESS_USER]")
     @NotNull(groups = OnSignUp.class, message = "회원 분류를 선택해 주세요.")
-    private Role role;
+    private List<Role> roles;
 
     @ApiModelProperty(value = "Base64로 인코딩된 프로필 이미지 데이터 URI", example = "YourEncodedDataURI")
     private String profileImage;

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/repository/PasswordResetTokenRepository.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,7 @@
+package personal.yeongyulgori.user.model.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import personal.yeongyulgori.user.model.entity.PasswordResetToken;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, String> {
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/model/repository/UserRepository.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/model/repository/UserRepository.java
@@ -3,7 +3,7 @@ package personal.yeongyulgori.user.model.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import personal.yeongyulgori.user.constant.Role;
+import personal.yeongyulgori.user.model.constant.Role;
 import personal.yeongyulgori.user.model.entity.User;
 
 import java.util.List;
@@ -15,7 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
 
-    List<User> findAllByRole(Role role);
+    List<User> findAllByRoles(Role role);
 
     boolean existsByEmail(String email);
 
@@ -23,6 +23,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByPhoneNumber(String phoneNumber);
 
-    Page<User> findByNameContaining(String keyword, Pageable pageable);
+    boolean existsByFullName(String fullName);
+
+    Page<User> findByFullNameContaining(String keyword, Pageable pageable);
 
 }

--- a/user-api/src/main/java/personal/yeongyulgori/user/security/CustomAuthenticationEntryPoint.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,59 @@
+package personal.yeongyulgori.user.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import personal.yeongyulgori.user.exception.ErrorResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final Logger log = LoggerFactory.getLogger(CustomAuthenticationEntryPoint.class);
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException e) throws IOException {
+
+        ErrorResponse errorResponse;
+
+        if (e instanceof UsernameNotFoundException) {
+
+            log.warn("Warning exception occurred: {}", e.getMessage(), e);
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+            errorResponse = ErrorResponse.builder()
+                    .statusCode(HttpServletResponse.SC_UNAUTHORIZED)
+                    .message(e.getMessage())
+                    .build();
+
+        } else {
+
+            log.error("Error exception occurred: {}", e.getMessage(), e);
+
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+            errorResponse = ErrorResponse.builder()
+                    .statusCode(HttpServletResponse.SC_FORBIDDEN)
+                    .message(e.getMessage())
+                    .build();
+
+        }
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        response.flushBuffer();
+
+    }
+
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/security/JwtAuthenticationFilter.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/security/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package personal.yeongyulgori.user.security;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String TOKEN_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    @Override
+    protected void doFilterInternal
+            (HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveTokenFromRequest(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+
+            try {
+
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.info(String.format("[%s] -> %s", jwtTokenProvider.getUsername(token), request.getRequestURI()));
+
+            } catch (UsernameNotFoundException e) {
+                customAuthenticationEntryPoint.commence(request, response, e);
+                return;
+            }
+
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+
+    private String resolveTokenFromRequest(HttpServletRequest request) {
+
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+
+    }
+
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/security/JwtTokenProvider.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/security/JwtTokenProvider.java
@@ -1,0 +1,88 @@
+package personal.yeongyulgori.user.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String KEY_ROLES = "roles";
+    private static final long TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 2;
+    private final UserDetailsService userDetailsService;
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    @PostConstruct
+    public void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    public String generateToken(String username, Collection<? extends GrantedAuthority> roles) {
+
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put(KEY_ROLES, roles);
+
+        Date now = new Date();
+        Date expirationTime = new Date(now.getTime() + TOKEN_EXPIRATION_TIME);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expirationTime)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(getUsername(token));
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+
+    }
+
+    public boolean validateToken(String token) {
+
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
+        Claims claims = parseClaims(token);
+        return !claims.getExpiration().before(new Date());
+
+    }
+
+    public String getUsername(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    private Claims parseClaims(String token) {
+
+        try {
+            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+
+    }
+
+}

--- a/user-api/src/main/java/personal/yeongyulgori/user/service/AuthenticationService.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/service/AuthenticationService.java
@@ -1,6 +1,7 @@
 package personal.yeongyulgori.user.service;
 
 import personal.yeongyulgori.user.model.dto.CrucialInformationUpdateDto;
+import personal.yeongyulgori.user.model.dto.SignInResponseDto;
 import personal.yeongyulgori.user.model.dto.UserResponseDto;
 import personal.yeongyulgori.user.model.form.InformationUpdateForm;
 import personal.yeongyulgori.user.model.form.SignInForm;
@@ -10,7 +11,7 @@ public interface AuthenticationService {
 
     UserResponseDto signUpUser(SignUpForm signUpForm);
 
-    String signInUser(SignInForm signInForm);
+    SignInResponseDto signInUser(SignInForm signInForm);
 
     UserResponseDto getUserDetails(String username);
 
@@ -20,7 +21,7 @@ public interface AuthenticationService {
 
     void requestPasswordReset(String email);
 
-    void resetPassword(String token, String password);
+    void resetPassword(String password);
 
     void deleteUser(String username, String password);
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/service/AuthenticationService.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/service/AuthenticationService.java
@@ -1,6 +1,7 @@
 package personal.yeongyulgori.user.service;
 
 import personal.yeongyulgori.user.model.dto.CrucialInformationUpdateDto;
+import personal.yeongyulgori.user.model.dto.PasswordRequestDto;
 import personal.yeongyulgori.user.model.dto.SignInResponseDto;
 import personal.yeongyulgori.user.model.dto.UserResponseDto;
 import personal.yeongyulgori.user.model.form.InformationUpdateForm;
@@ -23,6 +24,6 @@ public interface AuthenticationService {
 
     void resetPassword(String password);
 
-    void deleteUser(String username, String password);
+    void deleteUser(String username, PasswordRequestDto passwordRequestDto);
 
 }

--- a/user-api/src/main/java/personal/yeongyulgori/user/service/AuthenticationService.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/service/AuthenticationService.java
@@ -20,9 +20,9 @@ public interface AuthenticationService {
 
     void updateCrucialUserInformation(String username, CrucialInformationUpdateDto crucialInformationUpdateDto);
 
-    void requestPasswordReset(String email);
+    String requestPasswordReset(String email, String token);
 
-    void resetPassword(String password);
+    void resetPassword(String token, PasswordRequestDto passwordRequestDto);
 
     void deleteUser(String username, PasswordRequestDto passwordRequestDto);
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/service/UserService.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/service/UserService.java
@@ -8,6 +8,6 @@ public interface UserService {
 
     UserResponseDto getUserProfile(String username);
 
-    Page<UserResponseDto> getSearchedUsers(String name, Pageable pageable);
+    Page<UserResponseDto> getSearchedUsers(String fullName, Pageable pageable);
 
 }

--- a/user-api/src/main/java/personal/yeongyulgori/user/service/impl/AuthenticationServiceImpl.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/service/impl/AuthenticationServiceImpl.java
@@ -13,6 +13,7 @@ import personal.yeongyulgori.user.exception.general.sub.DuplicateUsernameExcepti
 import personal.yeongyulgori.user.exception.serious.sub.NonExistentUserException;
 import personal.yeongyulgori.user.exception.significant.sub.IncorrectPasswordException;
 import personal.yeongyulgori.user.model.dto.CrucialInformationUpdateDto;
+import personal.yeongyulgori.user.model.dto.PasswordRequestDto;
 import personal.yeongyulgori.user.model.dto.SignInResponseDto;
 import personal.yeongyulgori.user.model.dto.UserResponseDto;
 import personal.yeongyulgori.user.model.entity.User;
@@ -69,7 +70,7 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
             throw new IncorrectPasswordException();
         }
 
-        return SignInResponseDto.of(signedUpUser.getUsername(), signedUpUser.getAuthorities());
+        return SignInResponseDto.of(signedUpUser.getUsername(), signedUpUser.getRoles());
 
     }
 
@@ -120,16 +121,11 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
 
     }
 
-    // TODO
     @Override
-    public void deleteUser(String username, String password) {
+    public void deleteUser(String username, PasswordRequestDto passwordRequestDto) {
 
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new NonExistentUserException("해당 회원이 존재하지 않습니다. username: " + username));
-
-        if (!user.getPassword().equals(password)) {
-            throw new IncorrectPasswordException();
-        }
+        User user = validateUsernameAndPassword
+                (username, passwordRequestDto.getPassword());
 
         userRepository.delete(user);
 
@@ -168,5 +164,19 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
                         ("해당 회원이 존재하지 않습니다. username: " + emailOrUsername));
 
     }
+
+    private User validateUsernameAndPassword(String username, String password) {
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new NonExistentUserException("해당 회원이 존재하지 않습니다. username: " + username));
+
+        if (!user.getPassword().equals(password)) {
+            throw new IncorrectPasswordException();
+        }
+
+        return user;
+
+    }
+
 
 }

--- a/user-api/src/main/java/personal/yeongyulgori/user/service/impl/AuthenticationServiceImpl.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/service/impl/AuthenticationServiceImpl.java
@@ -118,6 +118,11 @@ public class AuthenticationServiceImpl implements AuthenticationService, UserDet
 
         validatePasswordIsCorrect(crucialInformationUpdateDto.getPassword(), user.getPassword());
 
+        if (crucialInformationUpdateDto.getNewPassword() != null) {
+            crucialInformationUpdateDto
+                    .setNewPassword(passwordEncoder.encode(crucialInformationUpdateDto.getNewPassword()));
+        }
+
         userRepository.save(user.withCrucialData(crucialInformationUpdateDto));
 
     }

--- a/user-api/src/main/java/personal/yeongyulgori/user/service/impl/AutoCompleteServiceImpl.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/service/impl/AutoCompleteServiceImpl.java
@@ -3,11 +3,8 @@ package personal.yeongyulgori.user.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.Trie;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StopWatch;
-import personal.yeongyulgori.user.exception.serious.sub.KeywordNotFoundException;
+import personal.yeongyulgori.user.exception.serious.sub.AutoCompleteValueNotFoundException;
 import personal.yeongyulgori.user.service.AutoCompleteService;
 
 import java.util.List;
@@ -19,50 +16,31 @@ public class AutoCompleteServiceImpl implements AutoCompleteService {
 
     private final Trie trie;
 
-    private static final Logger log = LoggerFactory.getLogger(AutoCompleteService.class);
-
     @Override
-    public void addAutoCompleteKeyWord(String name) {
-
-        log.info("Add autoComplete keyword by username: " + name);
-
-        trie.put(name, null);
-
+    public void addAutoCompleteKeyWord(String fullName) {
+        trie.put(fullName, "PRESENT");
     }
 
     @Override
     public List<String> autoComplete(String keyword) {
-
-        log.info("Beginning to retrieve autoComplete results by keyword: " + keyword);
-
-        StopWatch stopWatch = new StopWatch();
-
-        stopWatch.start();
 
         List<String> autoCompleteResults = (List<String>) trie.prefixMap(keyword).keySet()
                 .stream()
                 .limit(10)
                 .collect(Collectors.toList());
 
-        stopWatch.stop();
-
-        log.info("AutoComplete results retrieved successfully: {}\n Retrieving task execution time: {} ms",
-                keyword, stopWatch.getTotalTimeMillis());
-
         return autoCompleteResults;
 
     }
 
     @Override
-    public void deleteAutoCompleteKeyword(String keyword) {
+    public void deleteAutoCompleteKeyword(String fullName) {
 
-        log.info("Delete autoComplete keyword: " + keyword);
-
-        if (!trie.containsKey(keyword)) {
-            throw new KeywordNotFoundException("해당 자동완성 키워드가 존재하지 않습니다. keyword: " + keyword);
+        if (!trie.containsKey(fullName)) {
+            throw new AutoCompleteValueNotFoundException("해당 자동완성 성명이 존재하지 않습니다. fullName: " + fullName);
         }
 
-        trie.remove(keyword);
+        trie.remove(fullName);
 
     }
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/service/impl/UserServiceImpl.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/service/impl/UserServiceImpl.java
@@ -2,14 +2,11 @@ package personal.yeongyulgori.user.service.impl;
 
 
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StopWatch;
 import personal.yeongyulgori.user.model.dto.UserResponseDto;
 import personal.yeongyulgori.user.model.entity.User;
 import personal.yeongyulgori.user.model.repository.UserRepository;
@@ -21,27 +18,24 @@ import java.util.stream.Collectors;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
+/**
+ * 회원, 비회원 공용 서비스
+ */
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
 
-    private static final Logger log = LoggerFactory.getLogger(UserService.class);
-
     @Override
     @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
     public UserResponseDto getUserProfile(String username) {
 
-        log.info("Beginning to retrieve user profile for username: {}", username);
-
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new EntityNotFoundException("해당 회원이 존재하지 않습니다. username: " + username));
 
-        log.info("User profile retrieved successfully for username: {}", username);
-
-        return UserResponseDto.of(user.getEmail(), user.getUsername(), user.getName(),
-                user.getRole(), user.getCreatedAt(), user.getModifiedAt());
+        return UserResponseDto.of(user.getEmail(), user.getUsername(), user.getFullName(),
+                user.getRoles(), user.getCreatedAt(), user.getModifiedAt());
 
     }
 
@@ -49,22 +43,12 @@ public class UserServiceImpl implements UserService {
     @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 30)
     public Page<UserResponseDto> getSearchedUsers(String keyword, Pageable pageable) {
 
-        log.info("Beginning to retrieve searched users by keyword: {}", keyword);
-
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
-
-        Page<User> users = userRepository.findByNameContaining(keyword, pageable);
+        Page<User> users = userRepository.findByFullNameContaining(keyword, pageable);
 
         List<UserResponseDto> userResponseDtos = users.getContent().stream()
-                .map(user -> UserResponseDto.of(user.getEmail(), user.getUsername(), user.getName(),
-                        user.getRole(), user.getCreatedAt(), user.getModifiedAt()))
+                .map(user -> UserResponseDto.of(user.getEmail(), user.getUsername(), user.getFullName(),
+                        user.getRoles(), user.getCreatedAt(), user.getModifiedAt()))
                 .collect(Collectors.toList());
-
-        stopWatch.stop();
-
-        log.info("Searched users retrieved successfully: {}\n Retrieving task execution time: {} ms",
-                keyword, stopWatch.getTotalTimeMillis());
 
         return new PageImpl<>(userResponseDtos, pageable, users.getTotalElements());
 

--- a/user-api/src/main/java/personal/yeongyulgori/user/service/impl/UserServiceImpl.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/service/impl/UserServiceImpl.java
@@ -23,12 +23,12 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
  */
 @Service
 @RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
 
     @Override
-    @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
     public UserResponseDto getUserProfile(String username) {
 
         User user = userRepository.findByUsername(username)

--- a/user-api/src/main/java/personal/yeongyulgori/user/utility/MemoryUtil.java
+++ b/user-api/src/main/java/personal/yeongyulgori/user/utility/MemoryUtil.java
@@ -1,0 +1,9 @@
+package personal.yeongyulgori.user.utility;
+
+public class MemoryUtil {
+
+    public static long usedMemory() {
+        return Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+    }
+
+}

--- a/user-api/src/test/java/personal/yeongyulgori/user/controller/AuthenticationControllerTest.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/controller/AuthenticationControllerTest.java
@@ -273,7 +273,7 @@ class AuthenticationControllerTest {
                         .param("email", user.getEmail())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(status().isNoContent());
+                .andExpect(status().isOk());
 
     }
 

--- a/user-api/src/test/java/personal/yeongyulgori/user/model/repository/UserRepositoryTest.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/model/repository/UserRepositoryTest.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-import personal.yeongyulgori.user.constant.Role;
+import personal.yeongyulgori.user.model.constant.Role;
 import personal.yeongyulgori.user.model.entity.User;
 
 import java.time.LocalDate;
@@ -20,8 +20,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
-import static personal.yeongyulgori.user.constant.Role.BUSINESS_USER;
-import static personal.yeongyulgori.user.constant.Role.GENERAL_USER;
+import static personal.yeongyulgori.user.model.constant.Role.*;
+import static personal.yeongyulgori.user.testutil.TestConstant.*;
 import static personal.yeongyulgori.user.testutil.TestObjectFactory.createUser;
 
 @ActiveProfiles("test")
@@ -35,15 +35,15 @@ class UserRepositoryTest {
     @DisplayName("이메일 주소를 통해 해당 이메일 주소로 가입한 회원을 찾을 수 있다.")
     @ParameterizedTest
     @CsvSource({
-            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, GENERAL_USER",
-            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, BUSINESS_USER",
-            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, GENERAL_USER"
+            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, ROLE_GENERAL_USER",
+            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, ROLE_BUSINESS_USER",
+            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, ROLE_GENERAL_USER"
     })
-    void findByEmail(String username, String name, String email, String password,
+    void findByEmail(String username, String fullName, String email, String password,
                      LocalDate birthDate, String phoneNumber, Role role) {
 
         // given
-        User user = createUser(email, username, password, name, birthDate, phoneNumber, role);
+        User user = createUser(email, username, password, fullName, birthDate, phoneNumber, List.of(role));
 
         userRepository.save(user);
 
@@ -55,8 +55,8 @@ class UserRepositoryTest {
         assertThat(foundUser.getEmail()).isEqualTo(email);
         assertThat(foundUser.getUsername()).isEqualTo(username);
         assertThat(foundUser.getPassword()).isEqualTo(password);
-        assertThat(foundUser.getName()).isEqualTo(name);
-        assertThat(foundUser.getRole()).isEqualTo(role);
+        assertThat(foundUser.getFullName()).isEqualTo(fullName);
+        assertThat(foundUser.getRoles()).isEqualTo(user.getRoles());
 
     }
 
@@ -65,13 +65,13 @@ class UserRepositoryTest {
     void findByEmailWithNonExistentEmail() {
 
         // given
-        User user = createUser("abcd@abc.com", "person1", "1234", "홍길동",
-                LocalDate.of(1990, 01, 01), "01012345678", GENERAL_USER);
+        User user = createUser(EMAIL1, USERNAME1, PASSWORD1, FULL_NAME1,
+                BIRTH_DATE1, PHONE_NUMBER1, List.of(ROLE_GENERAL_USER));
 
         userRepository.save(user);
 
         // when
-        Optional<User> foundUser = userRepository.findByEmail("ab@abcd.com");
+        Optional<User> foundUser = userRepository.findByEmail(EMAIL2);
 
         // then
         assertThat(foundUser).isEmpty();
@@ -81,15 +81,15 @@ class UserRepositoryTest {
     @DisplayName("사용자 이름을 통해 해당하는 회원을 찾을 수 있다.")
     @ParameterizedTest
     @CsvSource({
-            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, GENERAL_USER",
-            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, BUSINESS_USER",
-            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, GENERAL_USER"
+            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, ROLE_GENERAL_USER",
+            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, ROLE_BUSINESS_USER",
+            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, ROLE_GENERAL_USER"
     })
-    void findByUsername(String username, String name, String email, String password,
+    void findByUsername(String username, String fullName, String email, String password,
                         LocalDate birthDate, String phoneNumber, Role role) {
 
         // given
-        User user = createUser(email, username, password, name, birthDate, phoneNumber, role);
+        User user = createUser(email, username, password, fullName, birthDate, phoneNumber, List.of(role));
 
         userRepository.save(user);
 
@@ -100,47 +100,60 @@ class UserRepositoryTest {
         assertThat(foundUser.getUsername()).isEqualTo(username);
         assertThat(foundUser.getEmail()).isEqualTo(email);
         assertThat(foundUser.getPassword()).isEqualTo(password);
-        assertThat(foundUser.getName()).isEqualTo(name);
-        assertThat(foundUser.getRole()).isEqualTo(role);
+        assertThat(foundUser.getFullName()).isEqualTo(fullName);
+        assertThat(foundUser.getRoles()).isEqualTo(user.getRoles());
 
     }
 
-    @DisplayName("입력한 분류에 해당하는 모든 회원 목록을 조회할 수 있다.")
+    @DisplayName("입력한 권한에 해당하는 모든 회원 목록을 조회할 수 있다.")
     @Test
-    void findAllByRole() {
+    void findAllByRoles() {
 
         // given
-        User user1 = createUser("abcd@abc.com", "person1", "1234", "홍길동",
-                LocalDate.of(1990, 01, 01), "01012345678", GENERAL_USER);
+        User user1 = createUser(EMAIL1, USERNAME1, PASSWORD1, FULL_NAME1,
+                LocalDate.of(1990, 01, 01),
+                PHONE_NUMBER1, List.of(ROLE_GENERAL_USER));
 
-        User user2 = createUser("abcd@abcd.com", "person2", "12345", "고길동",
-                LocalDate.of(2000, 02, 10), "01012345679", BUSINESS_USER);
+        User user2 = createUser(EMAIL2, USERNAME2, PASSWORD2, FULL_NAME2,
+                LocalDate.of(2000, 02, 10),
+                PHONE_NUMBER2, List.of(ROLE_BUSINESS_USER));
 
-        User user3 = createUser("abcd@abcde.com", "person3", "123456", "김길동",
-                LocalDate.of(2010, 03, 20), "01012345670", GENERAL_USER);
+        User user3 = createUser(EMAIL3, USERNAME3, PASSWORD3, FULL_NAME3,
+                LocalDate.of(2010, 03, 20),
+                PHONE_NUMBER3, List.of(ROLE_GENERAL_USER, ROLE_ADMIN));
 
-        User user4 = createUser("abcd@abcdef.com", "person4", "1234567", "길동",
-                LocalDate.of(2020, 04, 30), "01012345671", BUSINESS_USER);
+        User user4 = createUser(EMAIL4, USERNAME4, PASSWORD4, FULL_NAME4,
+                LocalDate.of(2020, 04, 30),
+                PHONE_NUMBER4, List.of(ROLE_BUSINESS_USER, ROLE_GENERAL_USER, ROLE_ADMIN));
 
         userRepository.saveAll(List.of(user1, user2, user3, user4));
 
         // when
-        List<User> selectedGeneralUsers = userRepository.findAllByRole(GENERAL_USER);
-        List<User> selectedBusinessUsers = userRepository.findAllByRole(BUSINESS_USER);
+        List<User> selectedGeneralUsers = userRepository.findAllByRoles(ROLE_GENERAL_USER);
+        List<User> selectedBusinessUsers = userRepository.findAllByRoles(ROLE_BUSINESS_USER);
+        List<User> selectedAdmins = userRepository.findAllByRoles(ROLE_ADMIN);
 
         // then
-        assertThat(selectedGeneralUsers).hasSize(2)
-                .extracting("email", "username", "name", "role")
+        assertThat(selectedGeneralUsers).hasSize(3)
+                .extracting("email", "username", "fullName", "roles")
                 .containsExactlyInAnyOrder(
-                        tuple("abcd@abc.com", "person1", "홍길동", GENERAL_USER),
-                        tuple("abcd@abcde.com", "person3", "김길동", GENERAL_USER)
+                        tuple(EMAIL1, USERNAME1, FULL_NAME1, user1.getRoles()),
+                        tuple(EMAIL3, USERNAME3, FULL_NAME3, user3.getRoles()),
+                        tuple(EMAIL4, USERNAME4, FULL_NAME4, user4.getRoles())
                 );
 
         assertThat(selectedBusinessUsers).hasSize(2)
-                .extracting("email", "username", "name", "role")
+                .extracting("email", "username", "fullName", "roles")
                 .containsExactlyInAnyOrder(
-                        tuple("abcd@abcd.com", "person2", "고길동", BUSINESS_USER),
-                        tuple("abcd@abcdef.com", "person4", "길동", BUSINESS_USER)
+                        tuple(EMAIL2, USERNAME2, FULL_NAME2, user2.getRoles()),
+                        tuple(EMAIL4, USERNAME4, FULL_NAME4, user4.getRoles())
+                );
+
+        assertThat(selectedAdmins).hasSize(2)
+                .extracting("email", "username", "fullName", "roles")
+                .containsExactlyInAnyOrder(
+                        tuple(EMAIL3, USERNAME3, FULL_NAME3, user3.getRoles()),
+                        tuple(EMAIL4, USERNAME4, FULL_NAME4, user4.getRoles())
                 );
 
     }
@@ -148,72 +161,100 @@ class UserRepositoryTest {
     @DisplayName("이메일을 통해 해당 회원의 가입 여부를 확인할 수 있다.")
     @ParameterizedTest
     @CsvSource({
-            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, GENERAL_USER",
-            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, BUSINESS_USER",
-            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, GENERAL_USER"
+            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, ROLE_GENERAL_USER",
+            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, ROLE_BUSINESS_USER",
+            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, ROLE_GENERAL_USER"
     })
-    void existsByEmail(String username, String name, String email, String password,
+    void existsByEmail(String username, String fullName, String email, String password,
                        LocalDate birthDate, String phoneNumber, Role role) {
 
         // given
-        User user = createUser(email, username, password, name, birthDate, phoneNumber, role);
+        User user = createUser(email, username, password, fullName, birthDate, phoneNumber, List.of(role));
 
         userRepository.save(user);
 
         // when
-        userRepository.existsByEmail(email);
+        boolean isEmailExists1 = userRepository.existsByEmail(email);
+        boolean isEmailExists2 = userRepository.existsByEmail(EMAIL4);
 
         // then
-        assertThat(userRepository.existsByEmail(email)).isTrue();
-        assertThat(userRepository.existsByEmail("ab@abcd.com")).isFalse();
+        assertThat(isEmailExists1).isTrue();
+        assertThat(isEmailExists2).isFalse();
 
     }
 
     @DisplayName("사용자 이름을 통해 해당 회원의 가입 여부를 확인할 수 있다.")
     @ParameterizedTest
     @CsvSource({
-            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, GENERAL_USER",
-            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, BUSINESS_USER",
-            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, GENERAL_USER"
+            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, ROLE_GENERAL_USER",
+            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, ROLE_BUSINESS_USER",
+            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, ROLE_GENERAL_USER"
     })
-    void existsByUsername(String username, String name, String email, String password,
+    void existsByUsername(String username, String fullName, String email, String password,
                           LocalDate birthDate, String phoneNumber, Role role) {
 
         // given
-        User user = createUser(email, username, password, name, birthDate, phoneNumber, role);
+        User user = createUser(email, username, password, fullName, birthDate, phoneNumber, List.of(role));
 
         userRepository.save(user);
 
         // when
-        userRepository.existsByUsername(email);
+        boolean isUsernameExists1 = userRepository.existsByUsername(username);
+        boolean isUsernameExists2 = userRepository.existsByUsername(USERNAME4);
 
         // then
-        assertThat(userRepository.existsByUsername(username)).isTrue();
-        assertThat(userRepository.existsByUsername("person4")).isFalse();
+        assertThat(isUsernameExists1).isTrue();
+        assertThat(isUsernameExists2).isFalse();
 
     }
 
     @DisplayName("휴대폰 번호를 통해 해당 회원의 가입 여부를 확인할 수 있다.")
     @ParameterizedTest
     @CsvSource({
-            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, GENERAL_USER",
-            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, BUSINESS_USER",
-            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, GENERAL_USER"
+            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, ROLE_GENERAL_USER",
+            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, ROLE_BUSINESS_USER",
+            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, ROLE_GENERAL_USER"
     })
-    void existsByPhoneNumber(String username, String name, String email, String password,
+    void existsByPhoneNumber(String username, String fullName, String email, String password,
                              LocalDate birthDate, String phoneNumber, Role role) {
 
         // given
-        User user = createUser(email, username, password, name, birthDate, phoneNumber, role);
+        User user = createUser(email, username, password, fullName, birthDate, phoneNumber, List.of(role));
 
         userRepository.save(user);
 
         // when
-        userRepository.existsByPhoneNumber(email);
+        boolean isPhoneNumberExists1 = userRepository.existsByPhoneNumber(phoneNumber);
+        boolean isPhoneNumberExists2 = userRepository.existsByPhoneNumber(PHONE_NUMBER4);
 
         // then
-        assertThat(userRepository.existsByPhoneNumber(phoneNumber)).isTrue();
-        assertThat(userRepository.existsByPhoneNumber("01012345681")).isFalse();
+        assertThat(isPhoneNumberExists1).isTrue();
+        assertThat(isPhoneNumberExists2).isFalse();
+
+    }
+
+    @DisplayName("성명을 통해 해당 회원의 가입 여부를 확인할 수 있다.")
+    @ParameterizedTest
+    @CsvSource({
+            "abcd@abc.com, person1, 1234, 홍길동, 1990-01-01, 01012345678, ROLE_GENERAL_USER",
+            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, ROLE_BUSINESS_USER",
+            "abcd@abcde.com, person3, 123456, 김길동, 2010-03-03, 01012345680, ROLE_GENERAL_USER"
+    })
+    void existsByFullName(String username, String fullName, String email, String password,
+                          LocalDate birthDate, String phoneNumber, Role role) {
+
+        // given
+        User user = createUser(email, username, password, fullName, birthDate, phoneNumber, List.of(role));
+
+        userRepository.save(user);
+
+        // when
+        boolean isFullNameExists1 = userRepository.existsByFullName(fullName);
+        boolean isFullNameExists2 = userRepository.existsByFullName(FULL_NAME4);
+
+        // then
+        assertThat(isFullNameExists1).isTrue();
+        assertThat(isFullNameExists2).isFalse();
 
     }
 
@@ -222,64 +263,64 @@ class UserRepositoryTest {
     void findByNameContaining() {
 
         // given
-        User user1 = createUser("abcd@abc.com", "person1", "1234", "홍길동",
-                LocalDate.of(1990, 01, 01), "01012345678", GENERAL_USER);
+        User user1 = createUser(EMAIL1, USERNAME1, PASSWORD1, FULL_NAME1,
+                LocalDate.of(1990, 01, 01), PHONE_NUMBER1, List.of(ROLE_GENERAL_USER));
 
-        User user2 = createUser("abcd@abcd.com", "person2", "12345", "고길동",
-                LocalDate.of(2000, 02, 10), "01012345679", BUSINESS_USER);
+        User user2 = createUser(EMAIL2, USERNAME2, PASSWORD2, FULL_NAME2,
+                LocalDate.of(2000, 02, 10), PHONE_NUMBER2, List.of(ROLE_BUSINESS_USER));
 
-        User user3 = createUser("abcd@abcde.com", "person3", "123456", "김길동",
-                LocalDate.of(2010, 03, 20), "01012345670", GENERAL_USER);
+        User user3 = createUser(EMAIL3, USERNAME3, PASSWORD3, FULL_NAME3,
+                LocalDate.of(2010, 03, 20), PHONE_NUMBER3, List.of(ROLE_GENERAL_USER));
 
-        User user4 = createUser("abcd@abcdef.com", "person4", "1234567", "홍길숙",
-                LocalDate.of(2020, 04, 30), "01012345671", BUSINESS_USER);
+        User user4 = createUser(EMAIL4, USERNAME4, PASSWORD4, FULL_NAME5,
+                LocalDate.of(2020, 04, 30), PHONE_NUMBER4, List.of(ROLE_BUSINESS_USER));
 
         userRepository.saveAll(List.of(user1, user2, user3, user4));
 
         // when
-        Page<User> foundUsers = userRepository.findByNameContaining("길동", Pageable.unpaged());
+        Page<User> foundUsers = userRepository.findByFullNameContaining(FIRST_NAME, Pageable.unpaged());
 
         // then
         assertThat(foundUsers).hasSize(3)
-                .extracting("email", "username", "name", "role")
+                .extracting("email", "username", "fullName", "roles")
                 .containsExactlyInAnyOrder(
-                        tuple("abcd@abc.com", "person1", "홍길동", GENERAL_USER),
-                        tuple("abcd@abcd.com", "person2", "고길동", BUSINESS_USER),
-                        tuple("abcd@abcde.com", "person3", "김길동", GENERAL_USER)
+                        tuple(EMAIL1, USERNAME1, FULL_NAME1, user1.getRoles()),
+                        tuple(EMAIL2, USERNAME2, FULL_NAME2, user2.getRoles()),
+                        tuple(EMAIL3, USERNAME3, FULL_NAME3, user3.getRoles())
                 );
 
     }
 
     @DisplayName("일부 일치하는 키워드를 통해 해당 키워드를 포함하는 이름을 가진 회원을 페이징 처리해 찾을 수 있다.")
     @Test
-    void findByNameContainingWithPaging() {
+    void findByFullNameContainingWithPaging() {
 
         // given
-        User user1 = createUser("abcd@abc.com", "person1", "1234", "홍길동",
-                LocalDate.of(1990, 01, 01), "01012345678", GENERAL_USER);
+        User user1 = createUser(EMAIL1, USERNAME1, PASSWORD1, FULL_NAME1,
+                LocalDate.of(1990, 01, 01), PHONE_NUMBER1, List.of(ROLE_GENERAL_USER));
 
-        User user2 = createUser("abcd@abcd.com", "person2", "12345", "고길동",
-                LocalDate.of(2000, 02, 10), "01012345679", BUSINESS_USER);
+        User user2 = createUser(EMAIL2, USERNAME2, PASSWORD2, FULL_NAME2,
+                LocalDate.of(2000, 02, 10), PHONE_NUMBER2, List.of(ROLE_BUSINESS_USER));
 
-        User user3 = createUser("abcd@abcde.com", "person3", "123456", "홍길숙",
-                LocalDate.of(2010, 03, 20), "01012345670", BUSINESS_USER);
+        User user3 = createUser(EMAIL3, USERNAME3, PASSWORD3, FULL_NAME5,
+                LocalDate.of(2010, 03, 20), PHONE_NUMBER3, List.of(ROLE_BUSINESS_USER));
 
-        User user4 = createUser("abcd@abcdef.com", "person4", "1234567", "홍길이",
-                LocalDate.of(2020, 04, 30), "01012345671", GENERAL_USER);
+        User user4 = createUser(EMAIL4, USERNAME4, PASSWORD4, FULL_NAME6,
+                LocalDate.of(2020, 04, 30), PHONE_NUMBER4, List.of(ROLE_GENERAL_USER));
 
         userRepository.saveAll(List.of(user1, user2, user3, user4));
 
         Pageable pageable = PageRequest.of(0, 2);
 
         // when
-        Page<User> foundUsers = userRepository.findByNameContaining("홍길", pageable);
+        Page<User> foundUsers = userRepository.findByFullNameContaining(FRONT_PART_OF_NAME, pageable);
 
         // then
         assertThat(foundUsers).hasSize(2)
-                .extracting("email", "username", "name", "role")
+                .extracting("email", "username", "fullName", "roles")
                 .containsExactlyInAnyOrder(
-                        tuple("abcd@abc.com", "person1", "홍길동", GENERAL_USER),
-                        tuple("abcd@abcde.com", "person3", "홍길숙", BUSINESS_USER)
+                        tuple(EMAIL1, USERNAME1, FULL_NAME1, user1.getRoles()),
+                        tuple(EMAIL3, USERNAME3, FULL_NAME5, user3.getRoles())
                 );
 
     }
@@ -289,31 +330,31 @@ class UserRepositoryTest {
     void findAllWithPaging() {
 
         // given
-        User user1 = createUser("abcd@abc.com", "person1", "1234", "홍길동",
-                LocalDate.of(1990, 01, 01), "01012345678", GENERAL_USER);
+        User user1 = createUser(EMAIL1, USERNAME1, PASSWORD1, FULL_NAME1,
+                LocalDate.of(1990, 01, 01), PHONE_NUMBER1, List.of(ROLE_GENERAL_USER));
 
-        User user2 = createUser("abcd@abcd.com", "person2", "12345", "고길동",
-                LocalDate.of(2000, 02, 10), "01012345679", BUSINESS_USER);
+        User user2 = createUser(EMAIL2, USERNAME2, PASSWORD2, FULL_NAME2,
+                LocalDate.of(2000, 02, 10), PHONE_NUMBER2, List.of(ROLE_BUSINESS_USER));
 
-        User user3 = createUser("abcd@abcde.com", "person3", "123456", "홍길숙",
-                LocalDate.of(2010, 03, 20), "01012345670", BUSINESS_USER);
+        User user3 = createUser(EMAIL3, USERNAME3, PASSWORD3, FULL_NAME5,
+                LocalDate.of(2010, 03, 20), PHONE_NUMBER3, List.of(ROLE_BUSINESS_USER));
 
-        User user4 = createUser("abcd@abcdef.com", "person4", "1234567", "홍길이",
-                LocalDate.of(2020, 04, 30), "01012345671", GENERAL_USER);
+        User user4 = createUser(EMAIL4, USERNAME4, PASSWORD4, FULL_NAME6,
+                LocalDate.of(2020, 04, 30), PHONE_NUMBER4, List.of(ROLE_GENERAL_USER));
 
         userRepository.saveAll(List.of(user1, user2, user3, user4));
 
         Pageable pageable = PageRequest.of(0, 2);
 
         // when
-        Page<User> foundUsers = userRepository.findByNameContaining("", pageable);
+        Page<User> foundUsers = userRepository.findByFullNameContaining("", pageable);
 
         // then
         assertThat(foundUsers).hasSize(2)
-                .extracting("email", "username", "name", "role")
+                .extracting("email", "username", "fullName", "roles")
                 .containsExactlyInAnyOrder(
-                        tuple("abcd@abc.com", "person1", "홍길동", GENERAL_USER),
-                        tuple("abcd@abcd.com", "person2", "고길동", BUSINESS_USER)
+                        tuple(EMAIL1, USERNAME1, FULL_NAME1, user1.getRoles()),
+                        tuple(EMAIL2, USERNAME2, FULL_NAME2, user2.getRoles())
                 );
 
     }

--- a/user-api/src/test/java/personal/yeongyulgori/user/service/AuthenticationServiceTest.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/service/AuthenticationServiceTest.java
@@ -14,6 +14,7 @@ import personal.yeongyulgori.user.exception.serious.sub.NonExistentUserException
 import personal.yeongyulgori.user.exception.significant.sub.IncorrectPasswordException;
 import personal.yeongyulgori.user.model.constant.Role;
 import personal.yeongyulgori.user.model.dto.CrucialInformationUpdateDto;
+import personal.yeongyulgori.user.model.dto.PasswordRequestDto;
 import personal.yeongyulgori.user.model.dto.SignInResponseDto;
 import personal.yeongyulgori.user.model.dto.UserResponseDto;
 import personal.yeongyulgori.user.model.entity.User;
@@ -466,8 +467,10 @@ class AuthenticationServiceTest {
 
         userRepository.save(user);
 
+        PasswordRequestDto passwordRequestDto = new PasswordRequestDto(password);
+
         // when
-        authenticationService.deleteUser(username, password);
+        authenticationService.deleteUser(username, passwordRequestDto);
 
         // then
         assertThat(userRepository.findById(user.getId()).isPresent()).isFalse();
@@ -484,9 +487,11 @@ class AuthenticationServiceTest {
 
         userRepository.save(user);
 
+        PasswordRequestDto passwordRequestDto = new PasswordRequestDto(PASSWORD1);
+
         // when, then
         assertThatThrownBy(() -> authenticationService
-                .deleteUser(USERNAME2, PASSWORD1))
+                .deleteUser(USERNAME2, passwordRequestDto))
                 .isInstanceOf(NonExistentUserException.class)
                 .hasMessage("해당 회원이 존재하지 않습니다. username: " + USERNAME2);
 
@@ -502,9 +507,11 @@ class AuthenticationServiceTest {
 
         userRepository.save(user);
 
+        PasswordRequestDto passwordRequestDto = new PasswordRequestDto(PASSWORD2);
+
         // when, then
         assertThatThrownBy(() -> authenticationService
-                .deleteUser(USERNAME1, PASSWORD2))
+                .deleteUser(USERNAME1, passwordRequestDto))
                 .isInstanceOf(IncorrectPasswordException.class)
                 .hasMessage("비밀번호가 일치하지 않습니다.");
 

--- a/user-api/src/test/java/personal/yeongyulgori/user/service/AutoCompleteServiceTest.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/service/AutoCompleteServiceTest.java
@@ -7,12 +7,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import personal.yeongyulgori.user.exception.serious.sub.KeywordNotFoundException;
+import personal.yeongyulgori.user.exception.serious.sub.AutoCompleteValueNotFoundException;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static personal.yeongyulgori.user.testutil.TestConstant.*;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -33,22 +34,17 @@ class AutoCompleteServiceTest {
     @Test
     void addAutoCompleteKeyWord() {
 
-        // given
-        String name1 = "홍길동";
-        String name2 = "고길동";
-        String name3 = "김길동";
-
-        // when
-        autoCompleteService.addAutoCompleteKeyWord(name1);
-        autoCompleteService.addAutoCompleteKeyWord(name2);
-        autoCompleteService.addAutoCompleteKeyWord(name3);
+        // given, when
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME1);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME2);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME3);
 
         // then
         assertThat(trie).hasSize(3);
 
-        assertThat(trie.containsKey("홍길동")).isTrue();
-        assertThat(trie.containsKey("고길동")).isTrue();
-        assertThat(trie.containsKey("김길동")).isTrue();
+        assertThat(trie.containsKey(FULL_NAME1)).isTrue();
+        assertThat(trie.containsKey(FULL_NAME2)).isTrue();
+        assertThat(trie.containsKey(FULL_NAME3)).isTrue();
 
     }
 
@@ -57,24 +53,18 @@ class AutoCompleteServiceTest {
     void autoComplete() {
 
         // given
-        String name1 = "홍길동";
-        String name2 = "고길동";
-        String name3 = "홍길춘";
-        String name4 = "김길동";
-        String name5 = "홍길순";
-
-        autoCompleteService.addAutoCompleteKeyWord(name1);
-        autoCompleteService.addAutoCompleteKeyWord(name2);
-        autoCompleteService.addAutoCompleteKeyWord(name3);
-        autoCompleteService.addAutoCompleteKeyWord(name4);
-        autoCompleteService.addAutoCompleteKeyWord(name5);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME1);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME2);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME5);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME3);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME6);
 
         // when
-        List<String> autoCompleteWords = autoCompleteService.autoComplete("홍길");
+        List<String> autoCompleteWords = autoCompleteService.autoComplete(FRONT_PART_OF_NAME);
 
         // then
         assertThat(autoCompleteWords).hasSize(3);
-        assertThat(autoCompleteWords).containsExactlyInAnyOrder("홍길동", "홍길춘", "홍길순");
+        assertThat(autoCompleteWords).containsExactlyInAnyOrder(FULL_NAME1, FULL_NAME5, FULL_NAME6);
 
     }
 
@@ -83,22 +73,18 @@ class AutoCompleteServiceTest {
     void deleteAutoCompleteKeyword() {
 
         // given
-        String name1 = "홍길동";
-        String name2 = "고길동";
-        String name3 = "김길동";
-
-        autoCompleteService.addAutoCompleteKeyWord(name1);
-        autoCompleteService.addAutoCompleteKeyWord(name2);
-        autoCompleteService.addAutoCompleteKeyWord(name3);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME1);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME2);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME3);
 
         // when
-        autoCompleteService.deleteAutoCompleteKeyword(name2);
+        autoCompleteService.deleteAutoCompleteKeyword(FULL_NAME2);
 
         // then
         assertThat(trie).hasSize(2);
-        assertThat(trie.containsKey("홍길동")).isTrue();
-        assertThat(trie.containsKey("고길동")).isFalse();
-        assertThat(trie.containsKey("김길동")).isTrue();
+        assertThat(trie.containsKey(FULL_NAME1)).isTrue();
+        assertThat(trie.containsKey(FULL_NAME2)).isFalse();
+        assertThat(trie.containsKey(FULL_NAME3)).isTrue();
 
     }
 
@@ -107,17 +93,14 @@ class AutoCompleteServiceTest {
     void deleteAutoCompleteKeywordByNonExistKeyword() {
 
         // given
-        String name1 = "홍길순";
-        String name2 = "고길동";
-        String name3 = "김길동";
-
-        autoCompleteService.addAutoCompleteKeyWord(name2);
-        autoCompleteService.addAutoCompleteKeyWord(name3);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME5);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME2);
+        autoCompleteService.addAutoCompleteKeyWord(FULL_NAME3);
 
         // when, then
-        assertThatThrownBy(() -> autoCompleteService.deleteAutoCompleteKeyword("홍길동"))
-                .isInstanceOf(KeywordNotFoundException.class)
-                .hasMessage("해당 자동완성 키워드가 존재하지 않습니다. keyword: 홍길동");
+        assertThatThrownBy(() -> autoCompleteService.deleteAutoCompleteKeyword(FULL_NAME1))
+                .isInstanceOf(AutoCompleteValueNotFoundException.class)
+                .hasMessage("해당 자동완성 성명이 존재하지 않습니다. fullName: " + FULL_NAME1);
 
     }
 

--- a/user-api/src/test/java/personal/yeongyulgori/user/service/UserDetailsServiceTest.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/service/UserDetailsServiceTest.java
@@ -1,0 +1,93 @@
+package personal.yeongyulgori.user.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.ActiveProfiles;
+import personal.yeongyulgori.user.model.entity.User;
+import personal.yeongyulgori.user.model.form.SignUpForm;
+import personal.yeongyulgori.user.model.repository.UserRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static personal.yeongyulgori.user.model.constant.Role.*;
+import static personal.yeongyulgori.user.testutil.TestConstant.*;
+import static personal.yeongyulgori.user.testutil.TestObjectFactory.enterUserForm;
+
+@ActiveProfiles
+@SpringBootTest
+public class UserDetailsServiceTest {
+
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+    @Autowired
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("가입된 사용자의 인증 정보와 권한 정보를 불러 올 수 있다.")
+    @Test
+    void loadUserByUsername() {
+
+        // given
+        SignUpForm signUpForm1 = enterUserForm
+                (EMAIL1, USERNAME1, PASSWORD1, FULL_NAME1, BIRTH_DATE1,
+                        PHONE_NUMBER1, List.of(ROLE_GENERAL_USER));
+
+        SignUpForm signUpForm2 = enterUserForm
+                (EMAIL2, USERNAME2, PASSWORD2, FULL_NAME2, BIRTH_DATE2,
+                        PHONE_NUMBER2, List.of(ROLE_BUSINESS_USER));
+
+        SignUpForm signUpForm3 = enterUserForm
+                (EMAIL3, USERNAME3, PASSWORD3, FULL_NAME3, BIRTH_DATE3,
+                        PHONE_NUMBER3, List.of(ROLE_ADMIN));
+
+        SignUpForm signUpForm4 = enterUserForm
+                (EMAIL4, USERNAME4, PASSWORD3, FULL_NAME4, BIRTH_DATE3,
+                        PHONE_NUMBER4, List.of(ROLE_GENERAL_USER, ROLE_BUSINESS_USER));
+
+        authenticationService.signUpUser(signUpForm1);
+        authenticationService.signUpUser(signUpForm2);
+        authenticationService.signUpUser(signUpForm3);
+        authenticationService.signUpUser(signUpForm4);
+
+        // when
+        List<User> users = userRepository.findAll();
+
+        UserDetails user1 = userDetailsService.loadUserByUsername(USERNAME1);
+        List<GrantedAuthority> authorities1 = new ArrayList<>(user1.getAuthorities());
+
+        UserDetails user2 = userDetailsService.loadUserByUsername(USERNAME2);
+        List<GrantedAuthority> authorities2 = new ArrayList<>(user2.getAuthorities());
+
+        UserDetails user3 = userDetailsService.loadUserByUsername(USERNAME3);
+        List<GrantedAuthority> authorities3 = new ArrayList<>(user3.getAuthorities());
+
+        UserDetails user4 = userDetailsService.loadUserByUsername(USERNAME4);
+        List<GrantedAuthority> authorities4 = new ArrayList<>(user4.getAuthorities());
+
+
+        // then
+        assertThat(user1.getUsername()).isEqualTo(USERNAME1);
+        assertThat(user1.getAuthorities()).isEqualTo(users.get(0).getAuthorities());
+
+        assertThat(user2.getUsername()).isEqualTo(USERNAME2);
+        assertThat(user2.getAuthorities()).isEqualTo(users.get(1).getAuthorities());
+
+        assertThat(user3.getUsername()).isEqualTo(USERNAME3);
+        assertThat(user3.getAuthorities()).isEqualTo(users.get(2).getAuthorities());
+
+        assertThat(user4.getUsername()).isEqualTo(USERNAME4);
+        assertThat(user4.getAuthorities()).isEqualTo(users.get(3).getAuthorities());
+
+    }
+
+}

--- a/user-api/src/test/java/personal/yeongyulgori/user/service/UserDetailsServiceTest.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/service/UserDetailsServiceTest.java
@@ -20,7 +20,7 @@ import static personal.yeongyulgori.user.model.constant.Role.*;
 import static personal.yeongyulgori.user.testutil.TestConstant.*;
 import static personal.yeongyulgori.user.testutil.TestObjectFactory.enterUserForm;
 
-@ActiveProfiles
+@ActiveProfiles("test")
 @SpringBootTest
 public class UserDetailsServiceTest {
 

--- a/user-api/src/test/java/personal/yeongyulgori/user/service/UserServiceTest.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/service/UserServiceTest.java
@@ -16,7 +16,6 @@ import personal.yeongyulgori.user.model.dto.UserResponseDto;
 import personal.yeongyulgori.user.model.entity.User;
 import personal.yeongyulgori.user.model.repository.UserRepository;
 
-import javax.persistence.EntityManager;
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDate;
 import java.util.List;
@@ -37,9 +36,6 @@ class UserServiceTest {
 
     @Autowired
     private UserRepository userRepository;
-
-    @Autowired
-    private EntityManager entityManager;
 
     @DisplayName("사용자 이름을 통해 다른 회원의 프로필을 조회할 수 있다.")
     @ParameterizedTest

--- a/user-api/src/test/java/personal/yeongyulgori/user/service/UserServiceTest.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/service/UserServiceTest.java
@@ -1,7 +1,6 @@
 package personal.yeongyulgori.user.service;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,60 +10,61 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
-import personal.yeongyulgori.user.constant.Role;
+import org.springframework.transaction.annotation.Transactional;
+import personal.yeongyulgori.user.model.constant.Role;
 import personal.yeongyulgori.user.model.dto.UserResponseDto;
 import personal.yeongyulgori.user.model.entity.User;
 import personal.yeongyulgori.user.model.repository.UserRepository;
 
+import javax.persistence.EntityManager;
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static personal.yeongyulgori.user.constant.Role.BUSINESS_USER;
-import static personal.yeongyulgori.user.constant.Role.GENERAL_USER;
+import static personal.yeongyulgori.user.model.constant.Role.ROLE_BUSINESS_USER;
+import static personal.yeongyulgori.user.model.constant.Role.ROLE_GENERAL_USER;
+import static personal.yeongyulgori.user.testutil.TestConstant.*;
 import static personal.yeongyulgori.user.testutil.TestObjectFactory.createUser;
 
 @ActiveProfiles("test")
 @SpringBootTest
+@Transactional
 class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
 
     @Autowired
     private UserRepository userRepository;
 
     @Autowired
-    private UserService userService;
-
-    @AfterEach
-    void tearDown() {
-        userRepository.deleteAllInBatch();
-    }
+    private EntityManager entityManager;
 
     @DisplayName("사용자 이름을 통해 다른 회원의 프로필을 조회할 수 있다.")
     @ParameterizedTest
     @CsvSource({
-            "abcd@abc.com, person1, 1234, 홍길동, 2000-01-01, 01012345678, GENERAL_USER",
-            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, BUSINESS_USER",
-            "abcd@abcde.com, person3, 123456, 김길동, 2000-03-03, 01012345680, GENERAL_USER"
+            "abcd@abc.com, person1, 1234, 홍길동, 2000-01-01, 01012345678, ROLE_GENERAL_USER",
+            "abcd@abcd.com, person2, 12345, 고길동, 2000-02-02, 01012345679, ROLE_BUSINESS_USER",
+            "abcd@abcde.com, person3, 123456, 김길동, 2000-03-03, 01012345680, ROLE_GENERAL_USER"
     })
     void getUserProfile(
             String email, String username, String password,
-            String name, LocalDate birthDate, String phoneNumber, Role role
+            String fullName, LocalDate birthDate, String phoneNumber, Role role
     ) {
 
         // given
-        User user = createUser(email, username, password, name, birthDate, phoneNumber, role);
+        User user = createUser(email, username, password, fullName, birthDate, phoneNumber, List.of(role));
 
         userRepository.save(user);
 
         // when
-        User foundUser = userRepository.findByUsername(username).get();
+        UserResponseDto userResponseDto = userService.getUserProfile(username);
 
         // then
-        assertThat(foundUser.getUsername()).isEqualTo(username);
-        assertThat(foundUser.getPassword()).isEqualTo(password);
-        assertThat(foundUser.getName()).isEqualTo(name);
-        assertThat(foundUser.getRole()).isEqualTo(role);
+        assertThat(userResponseDto.getUsername()).isEqualTo(username);
+        assertThat(userResponseDto.getFullName()).isEqualTo(fullName);
+        assertThat(userResponseDto.getRoles()).isEqualTo(user.getRoles());
 
     }
 
@@ -74,16 +74,16 @@ class UserServiceTest {
 
         // given
         User user = createUser(
-                "abcd@abc.com", "person1", "1234", "홍길동",
-                LocalDate.of(2000, 1, 1), "01012345678", Role.BUSINESS_USER
+                EMAIL1, USERNAME1, PASSWORD1, FULL_NAME1,
+                BIRTH_DATE1, PHONE_NUMBER1, List.of(ROLE_BUSINESS_USER)
         );
 
         userRepository.save(user);
 
         // when, then
-        assertThatThrownBy(() -> userService.getUserProfile("abcd@abcd.com"))
+        assertThatThrownBy(() -> userService.getUserProfile(USERNAME2))
                 .isInstanceOf(EntityNotFoundException.class)
-                .hasMessage("해당 회원이 존재하지 않습니다. username: " + "abcd@abcd.com");
+                .hasMessage("해당 회원이 존재하지 않습니다. username: " + USERNAME2);
 
 
     }
@@ -93,31 +93,31 @@ class UserServiceTest {
     void getSearchedUsers() {
 
         // given
-        User user1 = createUser("abcd@abc.com", "person1", "1234", "홍길동",
-                LocalDate.of(1990, 01, 01), "01012345678", GENERAL_USER);
+        User user1 = createUser(EMAIL1, USERNAME1, PASSWORD1, FULL_NAME1,
+                LocalDate.of(1990, 01, 01), PHONE_NUMBER1, List.of(ROLE_GENERAL_USER));
 
-        User user2 = createUser("abcd@abcd.com", "person2", "12345", "고길동",
-                LocalDate.of(2000, 02, 10), "01012345679", BUSINESS_USER);
+        User user2 = createUser(EMAIL2, USERNAME2, PASSWORD2, FULL_NAME2,
+                LocalDate.of(2000, 02, 10), PHONE_NUMBER2, List.of(ROLE_BUSINESS_USER));
 
-        User user3 = createUser("abcd@abcde.com", "person3", "123456", "김길동",
-                LocalDate.of(2010, 03, 20), "01012345670", GENERAL_USER);
+        User user3 = createUser(EMAIL3, USERNAME3, PASSWORD3, FULL_NAME3,
+                LocalDate.of(2010, 03, 20), PHONE_NUMBER3, List.of(ROLE_GENERAL_USER));
 
-        User user4 = createUser("abcd@abcdef.com", "person4", "1234567", "홍길숙",
-                LocalDate.of(2020, 04, 30), "01012345671", BUSINESS_USER);
+        User user4 = createUser(EMAIL4, USERNAME4, PASSWORD4, FULL_NAME5,
+                LocalDate.of(2020, 04, 30), PHONE_NUMBER4, List.of(ROLE_BUSINESS_USER));
 
         userRepository.saveAll(List.of(user1, user2, user3, user4));
 
         // when
         Page<UserResponseDto> userResponseDtos = userService.getSearchedUsers(
-                "길동", Pageable.ofSize(2)
+                FIRST_NAME, Pageable.ofSize(2)
         );
 
         // then
         Assertions.assertThat(userResponseDtos).hasSize(2)
-                .extracting("email", "username", "name", "role")
+                .extracting("email", "username", "fullName", "roles")
                 .containsExactlyInAnyOrder(
-                        tuple("abcd@abc.com", "person1", "홍길동", GENERAL_USER),
-                        tuple("abcd@abcd.com", "person2", "고길동", BUSINESS_USER)
+                        tuple(EMAIL1, USERNAME1, FULL_NAME1, user1.getRoles()),
+                        tuple(EMAIL2, USERNAME2, FULL_NAME2, user2.getRoles())
                 );
 
     }
@@ -126,17 +126,17 @@ class UserServiceTest {
     @Test
     void getUsersWithoutAnyKeyword() {
 
-        User user1 = createUser("abcd@abc.com", "person1", "1234", "홍길동",
-                LocalDate.of(1990, 01, 01), "01012345678", GENERAL_USER);
+        User user1 = createUser(EMAIL1, USERNAME1, PASSWORD1, FULL_NAME1,
+                LocalDate.of(1990, 01, 01), PHONE_NUMBER1, List.of(ROLE_GENERAL_USER));
 
-        User user2 = createUser("abcd@abcd.com", "person2", "12345", "고길동",
-                LocalDate.of(2000, 02, 10), "01012345679", BUSINESS_USER);
+        User user2 = createUser(EMAIL2, USERNAME2, PASSWORD2, FULL_NAME2,
+                LocalDate.of(2000, 02, 10), PHONE_NUMBER2, List.of(ROLE_BUSINESS_USER));
 
-        User user3 = createUser("abcd@abcde.com", "person3", "123456", "김길동",
-                LocalDate.of(2010, 03, 20), "01012345670", GENERAL_USER);
+        User user3 = createUser(EMAIL3, USERNAME3, PASSWORD3, FULL_NAME3,
+                LocalDate.of(2010, 03, 20), PHONE_NUMBER3, List.of(ROLE_GENERAL_USER));
 
-        User user4 = createUser("abcd@abcdef.com", "person4", "1234567", "홍길숙",
-                LocalDate.of(2020, 04, 30), "01012345671", BUSINESS_USER);
+        User user4 = createUser(EMAIL4, USERNAME4, PASSWORD4, FULL_NAME5,
+                LocalDate.of(2020, 04, 30), PHONE_NUMBER4, List.of(ROLE_BUSINESS_USER));
 
         userRepository.saveAll(List.of(user1, user2, user3, user4));
 
@@ -147,10 +147,10 @@ class UserServiceTest {
 
         // then
         Assertions.assertThat(userResponseDtos).hasSize(2)
-                .extracting("email", "username", "name", "role")
+                .extracting("email", "username", "fullName", "roles")
                 .containsExactlyInAnyOrder(
-                        tuple("abcd@abc.com", "person1", "홍길동", GENERAL_USER),
-                        tuple("abcd@abcd.com", "person2", "고길동", BUSINESS_USER)
+                        tuple(EMAIL1, USERNAME1, FULL_NAME1, user1.getRoles()),
+                        tuple(EMAIL2, USERNAME2, FULL_NAME2, user2.getRoles())
                 );
 
     }

--- a/user-api/src/test/java/personal/yeongyulgori/user/testutil/TestConstant.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/testutil/TestConstant.java
@@ -1,0 +1,38 @@
+package personal.yeongyulgori.user.testutil;
+
+import java.time.LocalDate;
+
+public class TestConstant {
+
+    public static final String EMAIL1 = "abcd@abc.com";
+    public static final String EMAIL2 = "abcd@abcd.com";
+    public static final String EMAIL3 = "abcd@abcde.com";
+    public static final String EMAIL4 = "abcd@abcdef.com";
+    public static final String USERNAME1 = "person1";
+    public static final String USERNAME2 = "person2";
+    public static final String USERNAME3 = "person3";
+    public static final String USERNAME4 = "person4";
+    public static final String USERNAME5 = "person5";
+    public static final String PASSWORD1 = "1234";
+    public static final String PASSWORD2 = "12345";
+    public static final String PASSWORD3 = "123456";
+    public static final String PASSWORD4 = "1234567";
+    public static final String FULL_NAME1 = "홍길동";
+    public static final String FULL_NAME2 = "고길동";
+    public static final String FULL_NAME3 = "김길동";
+    public static final String FULL_NAME4 = "이길동";
+    public static final String FULL_NAME5 = "홍길숙";
+    public static final String FULL_NAME6 = "홍길춘";
+    public static final String FIRST_NAME = "길동";
+    public static final String FRONT_PART_OF_NAME = "홍길";
+    public static final LocalDate BIRTH_DATE1 = LocalDate.of(2000, 1, 1);
+    public static final LocalDate BIRTH_DATE2 = LocalDate.of(2000, 2, 2);
+    public static final LocalDate BIRTH_DATE3 = LocalDate.of(2000, 3, 3);
+    public static final String PHONE_NUMBER1 = "01012345678";
+    public static final String PHONE_NUMBER2 = "01012345679";
+    public static final String PHONE_NUMBER3 = "01012345680";
+    public static final String PHONE_NUMBER4 = "01012345681";
+    public static final String CITY = "서울";
+    public static final String STREET = "테헤란로 231";
+
+}

--- a/user-api/src/test/java/personal/yeongyulgori/user/testutil/TestObjectFactory.java
+++ b/user-api/src/test/java/personal/yeongyulgori/user/testutil/TestObjectFactory.java
@@ -1,11 +1,12 @@
 package personal.yeongyulgori.user.testutil;
 
-import personal.yeongyulgori.user.constant.Role;
-import personal.yeongyulgori.user.model.Address;
+import personal.yeongyulgori.user.model.constant.Role;
 import personal.yeongyulgori.user.model.entity.User;
+import personal.yeongyulgori.user.model.entity.embedment.Address;
 import personal.yeongyulgori.user.model.form.SignUpForm;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.mockito.Mockito.mock;
 
@@ -14,33 +15,33 @@ public class TestObjectFactory {
     private static String originalTestImage = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxMTEBETEBIWFRUXFRoYGRgXFRgYFRUWGBcWGBgVFhcgHSkgGxoxHhgXITIhJS0uMC4wFyAzODMsNygtLisBCgoKDg0OGxAQGy0lICYtLS01Li0tLS0tLS4tLi0tLS0tLTUtLS0tLS0tLS0tLTUvLTUtLS0tLS0tLS0tLS0tLf/AABEIALgBEgMBIgACEQEDEQH/xAAcAAEAAgMBAQEAAAAAAAAAAAAABgcBBAUIAwL/xAA8EAACAQIEAwcCBQMDAgcAAAABAgADEQQFEiEGMUEHEyJRYXGBMpEUI0JSgnKhsTNikhWiJCVTY4Oy0f/EABoBAQADAQEBAAAAAAAAAAAAAAADBAUCAQb/xAA6EQABAgUBBgIIBAUFAAAAAAABAAIDBBEhMRIFQVFhcZGBoRMUIjKxwdHwM0KC4SNScqLxBiRikuL/2gAMAwEAAhEDEQA/ALxiIhEiIhEiIhEiIhEiIhEiIhEiIhEiIhEiIhEiIhEiIhEiIhEiJi8IsxOfjs1o0lJqVALC9ubne2yDxE+gEg3EHaUUY08NQYte2qoNgeX+mDqv6G3tOHxGs94q1KyUeZNITa88DvhWM1QAXOw8+k51DPcM7hKeIpM55KrqSbc9rythk2aZi2rEk0qRHJrquw2IpdTfe9us+PEnAj4OiMTRrMxpkFtrFTf6k57C457+shdGfTUG25q/D2bLBwhRI41mwDRUA7quxy6q4gZmcjhnNBiMLRrdWXxDycbMPuDOvLANRULIexzHFrsg07JERPVykREIkREIkREIkREIkREIkREIkREIkREIkREIkREIkREIkTF5y81z7D4cE16qp6c3PsouT9p4SAKldMY57tLRU8rrqz51HAFyQB68pWmb9ppIIwlAm91DupPitf6R6eZv6TRoZNmeYNrrkpTJLAVCyKvUBaQ3NiAQT5SAzArRgqVpt2TEa3XMOEMcyK9q/OqmGb8eYSiraW71wL6UvpO6j6yLfqHK8iOM4rzHGnu8HTZAbG9MNqClb2aobWN9ri3KSbKez3DUrNVvWf8A3bJv/sHT0N+UluHw601CU1VVAsFUAAD0AjRFf7xoOAXvrElL/gs1u4vx/wBbeGDzVc5P2dVWqGri8QwJN9KNrfmDYufYefKTXKeHMNh/9Gkob95F6h/md52YnbILGYCqzM/MTFnutwFh+/isATXxuGWpTem4urqVI8wRYzZiSqn0VddnGINDEYzA1DulQsl9i1rKxty32O3rLFkG40wn4fFYbMUBsrBKunqh2DH4JH2k2p1AQCORFx7SGD7ILOHwOFobQcIpbMD84v8A1Czu9nfqX7iIkyz0iIhEiIhEiIhEiIhEiIhEiIhEiIhEiIhEiJrYrFpTXVUdUA6uwUfcwgFTQLZmLyHZp2i4KlcKzVSP2WA/5Na/xeR1+0mpVp1e6prRIC92Xu+olgGHIDVY3HP6et5C6PDG/wC/gtCFsubiCoYQOdvLPkrNxFdEUs7KqgXJYgADzJPKRDOu0fCUbimTWfoE2X5c7W9ReRxMox+NUGpqsQLvX8AF730UlHtZrA+skGRdmuFpeKsTXb18KD0AG5HuTONcR/uCg4lWGyslL3mH6j/Kz5n/AAa7lFMRxZmeObRhKbIvIikDcf1P0+4nSyjs2qOe8xdbTc6tKeJvS7nkbe8srDYZKahaahVHIKAB9hNieiXBNXmpXj9rua3RLMEMcrk9Sf3PNcfKeHsNh/8ASpKGsLsRdzYWvfp8Tr2mYk4AGFlPe551OJJ5pE0c0zCnQpNVqmyKLkgEncgcgL8yJXWd9qe5TCUvapVI+LID9rnyuJw+K1nvFWZaRjzP4Tajjgd1Z1SsqglmAA5kkAD3MylQEAggg7gjcETz7nmd18UyFqjMGC7fpDCysFF7XvY39ZbnZ5iKrYGmKyMpTwrqFtVOwKW87Ahf4ziHMB7tICtTmynSsARHOBJNKY+Nz24KVRESdZS0M3oq9CqjLqDU2BHnsdvecLs8zXvsKFJOqkdG/Mpvof5AI/iZK7Ss8tJwGd1KR2pYkXXoBqZilvZrr/KQxDpe127B8cLQlIYjQIsL8w9sfprq8j405KzYmBMyZZ6REQiREQiREQiREQiREQiREQiRNPH5hTorqrVFRfNiB9vOQHP+1FEuuEpl+YDuDp26qoNzuRztOHxGM94q1LSUeYNITa88DubKx3qAC5Nh5+Ui+dcd4ShdQ/fP+2lZrdN25D7yoc34hxWLa1SszLcbAaUDH9OkbelzznY4c4NxlVlJTRTFyGq6lBBGk2As5222sNvvVMy5xowLabsSDAZrmog6Cw7nPQDxXX4k7QMQaFN6H5OqpUU7XcBFp8yRYG7nkPKQ6jRxeOb6atZ787sSNr2NzYD3tLbwHAWGC01rA1NBLBSxCAtpvYc7eEdeklGGwqU1C00VFHIKAAPgR6u959s/fwXg2tLSrNMtDvU3Nt5pzNt1adVWOVdlxcK2KfQOehbEi4FxfkN7+fxJ5k3DmGwwHc0gCL+I7tc8zfp8TtRLLILGXAWTM7QmZi0R1uAsO31qeaxaZmLzmZvnlDDC9esieQJux9lG5nZNMqo1rnnS0VPALqT8PUABJNgOZPISCV+1PCK1lWqw/dZAD6gFr/cCSbJs3o42iXpnUp8LKRZlJG6sPOxnLYjHGgKniycxBaHxWFo5j7/dcfN+PsJSISmxrOTYCmRpv6uSB9rza4L4lGOpO+kKyPYqDeykXQk/f7Sm89yhsPXrU/8A03KnyKHxKxPr5es7/ZrmAoY7SzAU64CDfclrFDa25vsTyBYyoyYeYgDlvTGyZdsq50GpdQEHjv6XBrxxdXBmODWrSqUnF1dCp9iCJ5zzTBGjWem99aMykH/aQLgW+ki9vjnPSwlP9reUd3XTEqNqgs39a2sfcrb/AIGSTbKt1cFW2DM6IxhHDhbqPqK9l8+yvF00xIpVaY1Mt0LAEqbLp07bbKdxz28paX/WsP3wo98neHfSDc/PkfSef6SMw8Ckc9Bt4rk3IBB2BAO+/v5dTh/h3H1atN6NN1CNcOdlRgQdmP1C4HK/+ZDCjuaNIFVoT+zYUaIYz4mm2/je9zjFR1PJX/E+dImw1Wvbe3K/W0+k0F8ikgXaplpOHpYpNnoODcDcISN/htJ+TJ7NXH4ValKpTf6XUqfYi04iM1tLVYlJgy8ZsUbj5YI8RVavD2ZDEYWjWH60Fx5ONmX4YETqSt+zHFtSq4rA1D4qbll+Dpa3psp+8sieQn62AnPzXc9LiBHcwYyOhuPLzqkREkVRIiIRIiIRIiIRInIzLOVpXUJUqv8AspU2c/JA0j5Mh2b4/OMT4cPhzh1I5ltNTmRbUbW6Ha0jfFa22TyVuBJPi3JDRxcQ0fup1iM0oobVK1NDa9mqKpt52Jlf8RdpoViuCVXs1izglT/SAwI+3l5zm0OzfFuWaq6Ate5LnUDYEEgA3N7g7yS8O9nFDDlXqsarjoQFQEi3L6jttufiQF0Z9gKLSZC2bLe09/pDwAt8T8bcDuiWbYbH1qSflO1bEAMwVD4KQ1hPF+ksSzEXAsFFhOnk3ZtVdE/F1igAANNCGNgbqNX0gi5/dLUEWnYlm1q41ULtsxtGmEA3mBU8BStgAKAWwFxsp4cw+HVBTpglBZWfxOASSbHpz6TsiZmCZOABYLKe9zzqcanmsxNDG5rRolRVqohZgqhmAJJ5ACcLj3iOrgqCVKSKxZit2vZTa48I58j16Txzw0EncpIMCJGe1jBd2K2HdSipUCgkmwHMnYCauAzGnWDGi6uFbSxU3AIANr/MoXGZzi8fV7tqlSoSbBEva/TSmygctzy85J+zLHjD4x8M7hu9G+lrqKouQoPU21AkbHbyldszqcBSy1o2xDBgOeX1eBWg4VvfpXhjtudoPE+Lo4lqGvuaekMrUx43U7fUTsb3G1uX3g+LzIYiqpqKL6EpXLGw0jSHZufOzHn1lkdr+Ud5hlrgeKkbNbrTY239mA/5GU2srTGoPIK29jtgxJVr2ihwaWvx4moIOabhS6k/GfDlXCMDVVDr3XuidBO+oHVvf15bidDspzc0MaKRPgrDR7Ntob7nT/Kb+dZ7SxeTUlNmxFO3hUFyAngZ2/2kMOfU+kgOCLh07sHVrW1vqFmuun1vacuIY8Ob1UsBj5qVdBjijqlp4WwRywfBWh2u5KWNLEJ1HdN73LJ7fqH2lbJqUUXVvECbWHiVhbT7ja49bz0BnmXnE4R6Z2dkBB/bUWzLb+QE8+YkHUVta+xHMggttfz3kk0yjq8VT2FMmJL6Dlh8jWnz7b60XojhvMhiMLRq7XZBqtyDjZgPkGanGuVficHUTTqK+NR1LJ0HuLj5kK7HM5P5uFc/+4n3CsPtpP3lj/8AUaJqdyKiGpYnQCC1ha+3zLbHCJDvvsvnpqC6TmyIf5TqHTI8Nx8V5yqmxZBspsQL7A2JB8z9RG/mZZ/ZVxBTGFqUazqvdHUCxAAQ2uAT5E/90hfH+U/hsdUC3Ct416WVzeyn0bUPiauByjvL1SSKNgCSCS7kAmnTUm7vcMdrjztKDHOhv6L6yZhwpyVFTQOoQcmv1yP8K6MFxZhqtUU6TFrtpD2IRn3bSt9ybKTe1uW+4khBlRZBwrjHq06iUVwqUwApqk6zZtWogeJnuOZsLGw5S3Ryl+C9zh7QXyc/LwYLwITq8bg06kW7LMwRMxJlQVacaUvweaYXGoPC/hqetrBvkof7GWSj3FxOBxrlzVsJU0XD07VUI+oPT8Q0+vMfM1OznNmxGCQ1CTUQlGJ5sATpY+tv8GQN9mIW8b/VaUYmPKMi72ewehu35hSyIiTrNSJgmaePzGlRXVWqLTXzYgX9vP4gmi9AJNBlbsxeV3nXafSUgYWmahvuzAgAX56fqPzacA4HNcyN3LU6Z6MTTp2uN1XmfMGx5c5A6YbWjbnktSHsmLp1zBENvF2fBue9OW5WxiMxpJ9dWmv9Tqv+TNelnmHdtNOqtQ+VO9S3vpvaRXJOzLD07NiXau3l9NP7A3PyfiTXB4RKahaaKijkFUKPsJ20xDkAeaqx2SrLQ3OfzoGjzqfJfdRM2mYkiqJETSzLMKdCm1Ws4RF5sfU2HL1hetBcaDK3YlYZ/wBqqLdcJSLHlqqbKN7X0je3uRIaONMa2ISs1YsEcMFBKoRf6dA25XG+8rPmmNxdbEDYc1EGp1G9c8unjRegDylNcYcd40VqtBNNAIxB03LkDrr+QdgJa2T5kmIo061I3Vxf1B6qfUG4PtKw7Ysm01aeJUbVBof+pRsT7qAP4T2ZLtFWlebGbC9a9HGaKmoFdzhup3HWir2piXdy1QuxJuxJJY/PU+ssz/qRzDJa6NZq1BVY35uqgWqc77qW+RK0Fa5Gyja2wtuosCfUdfOS3LMSuW17s16g8FWklmQI6nnUB3YEjwW59drSjDdpJrg2K+mn4QiNZpHttOpo6UqOABqAfDcuArvRp2AIeolrglWWmCwKkbad73v0BHWaeDrtSqU6qkalZWU87FWuAftOlh6yfi1aqxcMwLk9dZIcnlYHn6X62mrmuDajWq4c3BV9JuTZiG0hvKxuSCejTghWWEai0jIrjIwewpnqaEq/6RTG4ME/TXpbjy1rYj3B/uJ55zTCNQrVKLjxU2YH+LWuPQ8/kS1eyHNtVKrhWO9I3X+kmzAexsf5zi9sOS6a1PEqPDUGl/61HP5W32Mtx/bhh/D7+KwNln1SdfKuwcfEd2552UP4XwNSviadKjUFNjexJIAsDflz26dZcfDfA1DDMKrfmVvO1lU+aLvp977dLSjsvxbUqqVF2KvqB9Ry2npLKsatajTrL9LqGHpfmPe9x8RKtYSai4XX+oIkdmnSaMcKGnHNCc0O4Yyt20o3tNybucczICFrfmC3LV+sAedxf+Ql5yMcb8NfjaKKGCuj3VjyAOzX8x1t6SxHh62WysfZU2JaYBcfZNj9fA+VVTwwhw4pVnrFWqLq00ntUFNl+tmGy3vYLzPW02eDExP4yjVw9J30tdyA1mDaQwZidIOnV16yysi7OsNQ3qE12tvqGlD/APGDb735SXYegqqFRVVRyCgKB7AbSuyVNak0+K1JnbkMNcyGNdRSp9kUvuzv3nquBxPwlRxrUWqsw7u+6WBZTbw36bgG86WW5LQoKopJbSLKSSzAHmAxuQPadSJd0tqXUuvnjHimGIZcdIwN11gTMRPVEkwZzc1xFdF/8PSWo3+6poUf2JPtIRi8rzfFsUrOuHpE/pewt5WUlm+TaRvfpwCVbl5URbue1o5m/g3JUozri/C4YEVKwZxfwJ43v5G2w+bTT4EonRXrLT7qnVqF0S2k6budRXkDuACNiAPeMl4DwtA62Xv6l76qtmsb3uF5X9dzJYq2FhPGteSHPp0/ddxYkBkMw4Go1pVxtWl7N3dTfpVfqIiSqio1x9mtTDYJ6tCwcMBcgHSD1sefQfMgvD3BlbHBMTisTdX3ADl3sQbqb7Kb9N7Wlo5tgRXoVaR2DqVv5XHOVZwBnT4PEthcQbIahQg8qbglVIPkbWPxKsYD0g14PxW7s6JEEnE9XoIgNSaAktIwLbj36qwcl4SwmFsaVEF/3v4nvbmD0+LTv2gGZlkNDRQLFiRHxHankk8SapETmcQZquGw9Su++gbDlqYkBV+SRBIAqV4xpe4NaKk27rZxeNp0kL1XVFHNnYKv3MjeL4/wSPo1ux1afCosG8iWsB6Sns5z6viqpetUJa91A+lLHkByA9bb9ZvcScN1aKLiKmy1mLKFYkqWFwrbW1WJ6ymZpxrpGF9JC2HBYWiYfd2ALXzQZJtnHBXJknE2HxTMtGpdl5qdm22JHRh6i4n74uwYq4HFJpDE0mIB/co1L/cCUrwf+ITGJVwyM5UjUoBuykG9+gBF9zsDPQHNdxzHL36SWDE9K0grO2jJiQjtMM1wbm4I+tiPnReYGSxN+Ye1um3mfebOJwLIKb81qKWUgftLqb+twb/E+2f4MUsXWoqpFnZQD0KtYEehsD/KTzJso/8ALK1OrTp1a1FXqLT1XenTqKAwOm9n8BIAN7gcrygxhcSF9bMzbYTWv3OOORGfAkV4VWn2U8S91WbDVW8FVvCSdlq9Phvp9wPOWLxllX4rB1qYF2A1p/WoOn77j5lArUJfwqFe66dII8QAUafU8/Uy/OEszerQVa4016YAqKfq3GzlelxvY8txLUs8OaWFYW25cwYzZqHY1uOYwem486V95UgtCnSpNUqEGqzMFW+62JDOw5qeYAO/WdLMsEamEXGJzW1GtYi2tALOfNWQr/IHzMdouUdxmDhRZX/NXysxbUPuP8Ta7OMUjVamDrb08ShUg9HAujDyP1fJErge1oPTxWxEifwBMsqfzU/472+Av/U2pyooaurSevK4tYqb8yebbjeS7tAwpejgcao/1KSq5HIVqY0tv62t/CRzPspbDYirRq3BUmzAbMDup9iJPeGcKMZklbD2/MpNdd73YDWLeQPiX5iG3VVpz8x9leTcVsL0Uw0+yDc7tLxSvfSVC+Cc3OGxtKpfwFtL/wBBIDk+1x9hLp42yv8AE4GtTUXIUulurKCQB78vmVZkHAOKqhiVNJbAXqDSSLg3A57WB5by5cpwjUqFKm794yIFLWtqsLXtvLMs12khwsVjbajwhHZFguGtpvS+Liu6xqDvovPeW5HXxBC4egzG9jYbA78yfp2tsTLr4CyevhcIKOIZSQxZbHUQG3Kk2tzudvOSKhQVAAihQOgAA+wn3kkGXEM1rdUtobWfNt9GGgNrXie/7dUiIlhZKRNbF4tKS6qjqi+bEAf3kOzLtGwynRh/zXvYXPdp7hid/L1JE5c9rfeKngS0aOaQmk/AdTgd1Obzh5vxRhcOPzKoJ5FUIZgdtiOh3HO0rYZ9mWOrslMsFF/AikLsfoqddxcG5tJHgeAjUoUUxbaQhYlKRHiLG/jcjc9L897X2vIPTOf+GPErRds6FLketP8A0tuaUrw6DFL53H4V+0Cu2INLD4a9gxsdTVHsL2AFrf3kz4fxeIq0y+KorSYnZAbnT5t5HntPtl+VUaKhaSBbC1+bW52LG5PM8z1nRkrGPBq41VOYjwHNDYUMN53JPnQV8eqTFpmJIqaREQiREQiSoe1TK2pYlcRTXaqpD6RclwDfb2CkeRUmW9I/xtlX4jBV6Y+oDWvuu9vkXHzIo7NbCFf2bM+rzLXE2Nj0O/wz4LW4Az04rBoXv3ieBif1W5P8j+4MlMpHgTPTQxSLUOzHQTe40t4tzz1Bjf2LjqLXaJzLxNbOYXe1ZT1eYIAoDcd8eCzI5x9l5rZfiETchdQHnp8VvteSOYIkzhUEKjCiGG9r25BB7XXl0/V0Ftjbcep6++0nOX8aUxhqeGx2HFdaenSQ+5C30G1txp2vfe42na4k7NSapq4MpZmJNJyVUE8wpA5c9tucjON4Ix6gKaDPbcFWVgPDa2kNfn1t1maGRYZNvmF9m6akpxrauFri+lwPI1B5Wqpxl/aDgKY7vu2orsRZE0lTyYBTe1rdOsl2WZrRxCa6FRai9bHcHyI5j5nnPF4GpScrWRqbWJsQynrtuN+XPlOpwfnzYTF031eAmzi+zIbBtvMfV8SRk04GjsKpM7BhGGXwHHVnNQf89Spb2h0qWGxjVRTDVKiK13sVXmhKJyZtgfFsNtjIpwpxO2Cq1Klg+sMCt7A6irB9ha2x2HnJ12wYUPRw2IXxBWZTbqrjUp/7Tb3lTstrW5HcX6C5G/2kcYlkUkdVa2YyHMSQa+4I0mpOGnHLdinepO69cVK5raRTVn1HTewvuQov6GwnV4YzxsFjBU1a6THQxU3DKxufnr6EEdZLsTwhh6uUpWwlP83uxU1XJdrKRUT/AO1gOoE4WS9n9fEIrsppXb9Y0jRpHjUfVzJ229556J7SKZyuvXZWLDeIho0EsINK/M9M35gKZ9p2BFbBpiKJBKb35hqNRdJ+N1PtcysOH8rxD1qdTDI7urXsqt4N7qbnYDbrLv4eyLuMGMNWfvlsQdS2BVuaAft58/OdbD4ZEUJTRVUcgoAA9gJafL+kdqNlhS21vVIToLBruaE2GnmM5JNLZUcz/hOnjhh6lcGnUUeLRa5BFyl9xs3X38508i4fw+EUjD09Oq2okks1r21E+525bzsRLAY0HVS6yjMRTDELUdI3bkiYJmtisXTpqXquqKOZZgAPkzpQ8ltTBMhOa9oNFBUGHRqxS92FlpqRb6jztuN7W3ld5rxrjcU2gOyqxsEpBl236jdvvK75ljea1pXY0zHuRpHPPbPenVW7nfFGFwwPe1PEBfQg1Pv6Dl152kD4g7TKxuuFpClcbPUGp7EAhgvLkfWauTcAYusiGsRTQ2NnuXX0C/c72G/KTrJOB8JQIYp3rj9dQBrew5D7TisaJiwVnTs2T94+ld5fQf3H4qCYLKcVmNMM/esbAq9UstNWDANY9VI3so2KdLyS5F2ZYelZsSxqv5brTHpYbsPsPST7SJ+pI2XYLm5VSNteYcC2GdDeA3cq2p4UWvhcOlNQlNQqjYBRYD4mxESdZaREQiREQiREQiREQiTBmYhFQnHOVHC5gxTwq7d5Tax8Ookm23INfbfa0tfgfN/xODpsxBdfA9jcEqBZvkWPyZye1TJ+9wgrKPHROrluVbY/Y2b4MiXZRnIp4tqTnSKq2AA27weIAeWxI9biUW/wo1Nx+f7r6aL/AL7Zoifmh58M9236hXPEwDMy8vmVxuJ82bDYZ6y0+80kXF7WBNix25CUzm3G+LxJIaroTmBT8C7b7m9zt5mXtjcMtWm9NwGVwVYHqCLGUhnnA+Lw+IJp0mq0wQVKgtqF+TAC4PntaVJkP3YX0Gw3ytSIgGvILqX5CtgR3upLxfmVDGZPTrM698pQAXGvvNlqLbna12+AZA6ISnSQoNVZ+ZsStO5OkKtt32vfcWtbeSbA8G10AKUWaqzagrACjRXmpZjszW5AXAv57SXcL8BrRcV8U/fVeduaBuYYk7swI5nlItD4rq0pz+96utmpWShFjX6hUkCt7/lthvMkV3Atzs5vlFSvlCUWW9UUaZ0/qLqEJW5P1WuL+pkXyXstdgDi6mjf6UIZwDzBYjSDfyvLZEzLRgMcQTuFFgwtpTEGGWQzSpLsXva3Bc7Jsqp4aitGiCFW9rkk3JJJJ9yZ0BMxJgABQKi5xc4ucak70ia2KxSU1LVHVFHMsQAPkyL55x1Ro2FNWqs1LvEI2Rl8weZ5HkOhnLntbkqWDLxYxpDaT8O+OvBTAzh5zxVhcLtWqjV+xfE/yOnzaVBnPHOMxNwHKKTsKV1W19wTzb7/ABGScD4vFXYKUUn6qhIVgTuQLb+fzzlUzRcaQxVbjNhNhN1zcQNHAfU/IFSHOu06qwYYSmKYvYM41Mdrkrbwi2x3vOJhWr5glnSpUrU7lamprFSd1P6bgsCN15Eb7ScZJ2Z4ekFNdjWYb2O1IHrZRufk9JNcLhUpoEpoqKOSqAAPYCBAiPvEPh92Xj9pScsNMmy/82P/AEa+A5KveEez6pSLtiKgHeKyMib3RgAVY8hyB26gbya5RkGHww/IpKptYtzc+7HedaJYZCYzAWTMzseYJL3Z3Cwti31WBMxEkVRIiIRIiIRIiIRIiIRIiIRIiIRIiIRa+Lw61EZHF1ZSpHmGFiPtPP2ZUnwmN0W/MpVQUbqQHupPna4M9Eyre2PKQRRxCob/AOmxH3S48/qF/YSrNMq3UNy3NgzIhzHonYf8RjuKjxCsTKsatajSqryqIrD0uL2/yPib0gfZJmRqYNqbG7Uqh589L3Yf31SeSeG7W0OWXNwPQR3wuB8t3kkwZmJ2q6/OkT9RNbFYpKalqjKijmWYKB7kwnILZmLyD552k4WjdaYNVhzt4VHl4iN+fQGQjOeMsZiKYKOaSs2kJT2IsLkOb6jzW1tjY7Su+ZY22VqS2x5qMQSNI4n6Z7gDmrTzninCYa4rVV1fsXxP8qOXzaQLOu1Go11wqCmP31LM3wB4V+SZw8u4NxeK0sKPcgqLtU1LfYAmxF7nc8reRk4yXszw9OzYlmrMOl9FMfANz8n4kWuNE92wWgJfZkn+K7W7gL+QtX+pxVa95jMa5DLVrv03ZtO/QDZRY26Swco4Geph6P4lylanqC2Cm1I2Og7c7l/+bSe4TB06ShaSKigWAUAD+02pIyWaLuNfvv5qrNbaiRQGwmhgHicUx7oFzUU6768HKOF8Nh1UJSVipJVnUMylratJt4b26TugTMSwAAKBZD3uiOLnmp5pERPVwkREIkREIkREIkREIkREIkREIkREIkREIkREIk5XEeVricNVot+tfCf2uN1b7gTqzBE8IqKFdMeWODm5F1UXZQWo42rRfbXTbYgghkawuPZXlvSMjhKkuOGMRmV7ksNtLXWxHK485JpFBYWN0nir20pmHMxhFZvAryItTtQc8rBnGzfiPDYZSatUAj9K+J9+V16cus/XEuFq1cOUw7WcsvN2S6g+Ial3G3lIPl/ZX4mOJxJsT9NPc/LMOfxPYjng0aF5KQJVzS+PE003AVJ8b08RRa+cdqrE6cJSsN/G1i3XcAXA+byOrgMwx7hiKtUX+ptQReVwtyFA5y2Mr4OwdDdaAZv3VPGb+YvsPgCSCwkPoHv/ABHeA+/kr42rLSwpKQv1Oz9f7gOSrHLey3UWfF1bFiTppcrE30ksP8D/APZNsm4bw2GH5FFQf3HxPf8AqO45nlO1EnZCY3AWbMT8xHFHvNOAsOw+axaZiJIqaREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQiREQi//Z";
     public static final String TEST_IMAGE = originalTestImage.replaceAll("[^A-Za-z0-9+/=]", "");
 
-    public static SignUpForm enterUserForm(String email, String username, String password, String name,
-                                           LocalDate birthDate, String phoneNumber, Role role) {
+    public static SignUpForm enterUserForm(String email, String username, String password, String fullName,
+                                           LocalDate birthDate, String phoneNumber, List<Role> roles) {
 
         return SignUpForm.builder()
                 .email(email)
                 .username(username)
                 .password(password)
-                .name(name)
+                .fullName(fullName)
                 .birthDate(birthDate)
                 .phoneNumber(phoneNumber)
                 .address(mock(Address.class))
-                .role(role)
+                .roles(roles)
                 .profileImage(TEST_IMAGE)
                 .build();
 
     }
 
     public static SignUpForm enterUserFormWithAddress(
-            String email, String username, String password, String name,
-            LocalDate birthDate, String phoneNumber, Role role
+            String email, String username, String password, String fullName,
+            LocalDate birthDate, String phoneNumber, List<Role> roles
     ) {
 
         return SignUpForm.builder()
                 .email(email)
                 .username(username)
                 .password(password)
-                .name(name)
+                .fullName(fullName)
                 .birthDate(birthDate)
                 .phoneNumber(phoneNumber)
                 .address(Address.builder()
@@ -49,37 +50,37 @@ public class TestObjectFactory {
                         .zipcode("12345")
                         .detailedAddress("101동 102호")
                         .build())
-                .role(role)
+                .roles(roles)
                 .profileImage(TEST_IMAGE)
                 .build();
 
     }
 
-    public static User createUser(String email, String username, String password, String name,
-                                  LocalDate birthDate, String phoneNumber, Role role) {
+    public static User createUser(String email, String username, String password, String fullName,
+                                  LocalDate birthDate, String phoneNumber, List<Role> roles) {
 
         return User.builder()
                 .email(email)
                 .username(username)
                 .password(password)
-                .name(name)
+                .fullName(fullName)
                 .birthDate(birthDate)
                 .phoneNumber(phoneNumber)
                 .address(mock(Address.class))
                 .profileImage(TEST_IMAGE.getBytes())
-                .role(role)
+                .roles(roles)
                 .build();
 
     }
 
-    public static User createUserWithAddress(String email, String username, String password, String name,
-                                             LocalDate birthDate, String phoneNumber, Role role) {
+    public static User createUserWithAddress(String email, String username, String password, String fullName,
+                                             LocalDate birthDate, String phoneNumber, List<Role> roles) {
 
         return User.builder()
                 .email(email)
                 .username(username)
                 .password(password)
-                .name(name)
+                .fullName(fullName)
                 .birthDate(birthDate)
                 .phoneNumber(phoneNumber)
                 .address(Address.builder()
@@ -89,7 +90,7 @@ public class TestObjectFactory {
                         .detailedAddress("101동 102호")
                         .build())
                 .profileImage(TEST_IMAGE.getBytes())
-                .role(role)
+                .roles(roles)
                 .build();
 
     }


### PR DESCRIPTION
## 추가사항
- Spring Security 적용
- 비즈니스 로직의 메모리 성능을 측정하는 로깅 추가([LoggingAspect](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-b12b3faa74ec3a585acfb2f11e282d948739bc12497d00466d732e2ed27a41f0))

## 변경사항
- Spring Security 적용에 맞춰 테스트 코드 수정, 개선

## 주요 구현사항

- 테스트 코드
    - [AuthenticationController 테스트](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-c8a1d31a603749e4c0bde832e8d0795f0327e988d24cd141e374d1fb0a3d3a42)
    - [UserController 테스트](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-c86ddc4b3ad7b8fd506fb1acc2e655708c5e5752e4421dc1600d9ac540588d90)
    - [AuthenticationService 테스트](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-48afee47f0450c250878038bad0adddb24cd3b43641cc904b7d024a1d95fc1aa)
    - [UserDetailsService 테스트](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-e3a58df439171f6dc4d01b8af856680300ea4b7cd4e0c2151dc9c5b25e8488ea)
    - [UserRepository 테스트](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-dd36030704799faa94050ef44813a391314d643d9459238140aae528345ab34d)

- 프로덕션 코드
    - [AuthenticationController](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-f0bc876c2b7464e4f0f34456d85f2b6a10a1900fa3d3eb6c73d64e85eb227422)
    - [AuthenticationService](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-aaaf14658391786ba514084f406c6382241b63ca768999bb6acf70187b917491)
    - [User](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-4a71b235db538511d433ec60beb6902616842d2bc7428fc00ea3ca2513ce2764)
    - [PasswordResetToken](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-7fbee1ce009fbbf3fbd663062a3589ac8a0f0cfbba7ffa3aebf802253f483e8c)

- 보안 코드
    - [WebSecurityConfig](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-f29dcfff7fa3d96e29e5fe84a0ee7ee45041e36aa95a86a43a5b2e3ff2a4696a)
    - [JwtTokenProvider](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-f200b1b041658337fae8bdcbafd9f2c86f901b2b44de81a8fd58af71d8f6125b)
    - [JwtAuthenticationFilter](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-d46348c454fe6b9b0755dda3c665e5b34277aec47b27096e4dee15656cf97dc7)
    - [CustomAuthenticationEntryPoint](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-53d36fe0f3517409bcc2140ebf442533e78c8235df2d4ab6d6c562882acb79d2)

- 유틸리티 코드
    - [LoggingAspect](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-b12b3faa74ec3a585acfb2f11e282d948739bc12497d00466d732e2ed27a41f0)
    - [MemoryUtil](https://github.com/hellmir/yeongyulgori/pull/25/files#diff-1e41727f922d40f44260b38572580b8ea442363bc195e8fcc005dcdc29d40516)

## 발생 이슈 & 해결 과정

### 이슈
1. UserController 테스트와 AuthenticationController 테스트에서 401 Status Code가 반환되는 문제 발생
2. AuthenticationController 테스트에서 403 Status Code가 반환되는 문제 발생
3. AuthenticationController 테스트에서 Status Code가 항상 200으로만 반환되는 문제 발생
4. Post API와 마찬가지로 테스트 코드에서 Redis 서버 분리 실패(Embedded Redis가 적용되지 않고 실제 Redis 서버에서 테스트 진행) -> Redis 적용 시 배포가 중단되므로 보류(해결 중)
5. User 엔티티의 name이라는 필드명이 사용자 이름으로 주로 쓰이는 username과 비교해 사용자의 본명이라는 것이 잘 드러나지 않는 문제

### 해결 과정
1. @WithMockUser 어노테이션을 사용함으로써 해결
2. WebSecurityConfig에서 CSRF 보호를 비활성화했으므로, Stateless가 적용되지 않는 AuthenticationController 테스트 요청 시 .with(csrf())를 통해 활성화함으로써 해결
3. AuthenticationController 클래스를 @Mock이 아닌 @Autowired를 통해 실제 객체의 의존성을 주입함으로써 해결
(참고: https://stackoverflow.com/questions/76347086/integration-test-fails-getting-200-status-code-instead-of-201-spring-boot-ja)
4. 해결 방안
    1. Jenkins 서버에서 배포 서버와 마찬가지로 각각의 API에 대해 Redis 서버를 컨테이너화해 테스트 -> API가 많아질 수록 Jenkins 서버에 부담이 늘어남(worse)
    2. Embedded Redis의 테스트 클래스 적용에 대해 심화 학습(better)
5. 소셜 미디어 서비스 instagram의 변수명을 참고해 fullName이라는 필드명으로 수정